### PR TITLE
fix: nightly build command for binary

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,7 +87,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --features cli --target ${{ matrix.target }}
 
       - name: Package (unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Fix nightly build to produce the correct binary.
- copia: add `--features cli` (required-features)
- trueno-rag: add `-p trueno-rag-cli` (binary in subcrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)