### PR TITLE
feat(ci): opt in to cargo nextest run (Phase 2 pilot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       # Phase 3 pilot (light workload) — build-performance.md §7 Phase 3.
       # Few deps, short cold build — break-even candidate for hit-rate signal.
       enable_sccache: true
+      use_nextest: true
     secrets: inherit
 
   # Top-level gate: org ruleset requires status check named "gate" (exact match).


### PR DESCRIPTION
## Summary

Opts copia into `use_nextest: true` on the reusable sovereign CI workflow (`paiml/.github/.github/workflows/sovereign-ci.yml`). Part of the Phase 2 nextest pilot cohort (copia, bashrs, aprender) — same cohort as the PMAT-151 sccache Phase 3 pilot that just shipped.

- Refs PMAT-155
- F11 baseline p95 = 168s for copia (measured via `cargo run --example falsify_f11_test_job_p95`, see paiml/infra#52)
- After 7 days of measurement, if p95 ≤ 300s we flip the reusable workflow's default to true

## Test plan

- [ ] CI `gate` passes green on this PR
- [ ] Falsifier shows p95 ≤ 300s over 7-day window post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)