### PR TITLE
feat(sync): incremental recursive sync — quick-check, atomic, mtime, --delete/--exclude/--dry-run (L1-L4 contract)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ required-features = ["cli"]
 
 [lints.rust]
 unsafe_code = "deny"
+# `cfg(kani)` is set by the Kani model checker (`cargo kani`), not by a feature.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/contracts/incremental-sync-v1.yaml
+++ b/contracts/incremental-sync-v1.yaml
@@ -1,0 +1,155 @@
+metadata:
+  id: C-COPIA-INCREMENTAL-SYNC
+  version: "1.0.0"
+  created: "2026-07-04"
+  author: "PAIML Engineering"
+  kind: pattern
+  status: ACTIVE
+  description: |
+    Pins copia's incremental recursive sync (the rsync-parity core): a run
+    transfers ONLY new-or-changed files (quick check on size+mtime), delivers
+    every file atomically (temp `.copia-tmp` + rename), preserves mtime so the
+    NEXT run's quick check is stable, honours `--exclude` filters, mirrors with
+    `--delete`, and previews with `--dry-run` — across all three directions
+    (push local->remote, pull remote->local, local->local).
+  references:
+    - "plan::needs_transfer / build_plan — the pure quick-check + plan diff (Kani-proved)"
+    - "incremental::run_remote / run_local — orchestration; deliver_pull / deliver_local — atomic delivery"
+    - "transfer::transfer_file_to_remote — remote atomic write (cat > tmp && mv -f) + touch -d @mtime"
+    - "meta::discover_*_with_meta — both-sides size+mtime discovery driving the diff"
+
+equations:
+  quick_check:
+    formula: "transfer(p) <=> (p not in dst) OR size(src/p) != size(dst/p) OR mtime(src/p) != mtime(dst/p)"
+    domain: "p in relpaths(src); size in u64, mtime in whole epoch seconds"
+    codomain: "boolean transfer decision per file"
+    invariants:
+      - "A file whose size AND mtime match the destination is NEVER re-transferred (skip)"
+      - "A file absent from the destination is ALWAYS transferred (new)"
+      - "mtime is compared at 1-second granularity (find %T@ truncated vs SystemTime)"
+  atomic_delivery:
+    formula: "for all readers r, observe(dst/p) in {old(dst/p), new(src/p)} — never a partial write"
+    domain: "any interleaving of a reader with an interrupted transfer"
+    invariants:
+      - "Bytes land in a sibling `<dst>.copia-tmp` and are rename(2)'d into place only after a clean transfer"
+      - "An interrupted push/pull leaves the destination file untouched (old) or fully replaced (new)"
+      - "No `.copia-tmp` staging file survives a successful transfer"
+  mtime_preservation:
+    formula: "after transfer(p): mtime(dst/p) == mtime(src/p) (whole seconds)"
+    domain: "p in transfer set"
+    invariants:
+      - "Push sets the remote mtime via `touch -d @<secs>`; pull/local via File::set_modified"
+      - "Preserving mtime is what makes the NEXT run's quick check skip the file (stability)"
+  exclude_filtering:
+    formula: "excluded(p) => p not in transfer AND p not in delete"
+    domain: "p in relpaths(src) union relpaths(dst); patterns are gitignore-style globs"
+    invariants:
+      - "A slash-free pattern matches any path component; a pattern with `/` matches the whole relative path"
+      - "An excluded destination path is left untouched — never deleted by --delete"
+  delete_mirror:
+    formula: "with --delete: delete set = { p in dst : p not in src AND not excluded(p) }"
+    domain: "p in relpaths(dst)"
+    invariants:
+      - "Without --delete the delete set is empty (never removes anything)"
+      - "--dry-run computes the delete set but removes nothing"
+
+proof_obligations:
+  - type: invariant
+    property: "Quick-check correctness"
+    formal: "needs_transfer(s, d) == (d is None) OR s.size != d.size OR s.mtime != d.mtime"
+    applies_to: quick_check
+    lean:
+      theorem: Theorems.QuickCheckCorrect
+      status: proved
+  - type: invariant
+    property: "Skip guarantee"
+    formal: "size(src/p)==size(dst/p) AND mtime(src/p)==mtime(dst/p) => p not in transfer"
+    applies_to: quick_check
+    lean:
+      theorem: Theorems.SkipGuarantee
+      status: proved
+  - type: roundtrip
+    property: "Atomic delivery"
+    formal: "a completed sync yields dst/p byte-identical to src/p with no surviving .copia-tmp"
+    applies_to: atomic_delivery
+    lean:
+      theorem: Theorems.AtomicDelivery
+      status: sorry
+  - type: invariant
+    property: "mtime stability (idempotence)"
+    formal: "sync; sync => second run transfers 0 files (all skipped)"
+    applies_to: mtime_preservation
+    lean:
+      theorem: Theorems.MtimeIdempotence
+      status: sorry
+  - type: invariant
+    property: "Exclude safety"
+    formal: "excluded(p) => p not in transfer AND p not in delete"
+    applies_to: exclude_filtering
+    lean:
+      theorem: Theorems.ExcludeSafety
+      status: sorry
+  - type: invariant
+    property: "Delete is opt-in"
+    formal: "NOT with_delete => delete set empty"
+    applies_to: delete_mirror
+    lean:
+      theorem: Theorems.DeleteOptIn
+      status: proved
+
+falsification_tests:
+  - id: FALSIFY-INCR-001
+    rule: "Skip guarantee / idempotence"
+    prediction: "A second sync of an unchanged tree transfers 0 files (all skipped)"
+    test: "e2e: sync twice; assert the 2nd run reports 0 to transfer and 'up to date'"
+    if_fails: "Quick check re-transfers unchanged files (mtime not preserved, or size/mtime not compared)"
+  - id: FALSIFY-INCR-002
+    rule: "Quick-check correctness"
+    prediction: "needs_transfer transfers iff new or size/mtime differ"
+    test: "unit: needs_transfer_matches_the_quick_check_rule; Kani: plan-kani-001 (exhaustive)"
+    if_fails: "A changed file is skipped (data loss) or an identical file re-sent (waste)"
+  - id: FALSIFY-INCR-003
+    rule: "Atomic delivery"
+    prediction: "After a sync no `.copia-tmp` survives and dst == src byte-for-byte"
+    test: "e2e: sync a tree; assert content identical and find '*.copia-tmp' is empty"
+    if_fails: "Delivery wrote in place (torn-file risk) or left staging files behind"
+  - id: FALSIFY-INCR-004
+    rule: "Exclude safety"
+    prediction: "`--exclude '*.tmp'` leaves matching files out of dst and never deletes an excluded dst path"
+    test: "e2e: source has skip.tmp; after sync skip.tmp is absent from dst"
+    if_fails: "Exclude glob failed to match, dragging junk across (or deleting an excluded dest file)"
+  - id: FALSIFY-INCR-005
+    rule: "Delete mirror + opt-in"
+    prediction: "`--delete` removes a dst file absent from src; without it, nothing is removed"
+    test: "e2e: remove a src file, sync --delete, assert dst mirror no longer has it; and a no-delete run keeps it"
+    if_fails: "Mirror left stale files, or --delete removed files it shouldn't have (foot-gun)"
+  - id: FALSIFY-INCR-006
+    rule: "Dry-run purity"
+    prediction: "`--dry-run` prints the plan but mutates neither side"
+    test: "e2e: add a src file, sync -n, assert the file is NOT created on dst"
+    if_fails: "Dry-run performed real transfers/deletes"
+
+kani_harnesses:
+  - id: plan-kani-001
+    obligation: "Quick-check correctness"
+    harness: "plan::kani_proofs::needs_transfer_iff_new_or_differing"
+    bound: 0
+    strategy: exhaustive
+    status: PROVED
+    notes: "cargo kani --features cli — SUCCESS, exhaustive over all (size,mtime) pairs for new/identical/differing"
+
+qa_gate:
+  id: F-INCR-001
+  name: Incremental Sync Contract
+  description: >
+    copia's recursive sync is incremental (quick-check skip), atomic, mtime-stable,
+    exclude-aware, mirror-capable, and dry-runnable.
+  checks:
+    - quick_check
+    - atomic_delivery
+    - mtime_preservation
+    - exclude_filtering
+    - delete_mirror
+  pass_criteria: >
+    All 6 FALSIFY-INCR falsification tests pass (L2) AND the plan-kani-001 Kani
+    harness verifies quick-check correctness exhaustively (L3).

--- a/lean/IncrementalSync.lean
+++ b/lean/IncrementalSync.lean
@@ -1,0 +1,33 @@
+/-
+  L4 Lean 4 proofs for copia `incremental-sync-v1`.
+  Self-contained (no Mathlib): the quick-check + delete-opt-in facts are
+  decidable boolean identities. Mirrors `plan::needs_transfer` / `build_plan`.
+  Verify: `lean lean/IncrementalSync.lean` (0 errors, no `sorry`).
+-/
+namespace ProvableContracts.Copia
+
+/-- The per-file quick-check decision, mirroring `plan::needs_transfer`:
+    transfer iff the destination is absent or differs in size or mtime. -/
+def needsTransfer (ssize dsize : Nat) (smtime dmtime : Int) (present : Bool) : Bool :=
+  if present then (ssize != dsize || smtime != dmtime) else true
+
+/-- Theorems.QuickCheckCorrect — a present file transfers iff size or mtime differ. -/
+theorem QuickCheckCorrect (ssize dsize : Nat) (smtime dmtime : Int) :
+    needsTransfer ssize dsize smtime dmtime true
+      = (ssize != dsize || smtime != dmtime) := by
+  simp [needsTransfer]
+
+/-- Theorems.SkipGuarantee — an identical (size, mtime) file is never re-transferred. -/
+theorem SkipGuarantee (size : Nat) (mtime : Int) :
+    needsTransfer size size mtime mtime true = false := by
+  simp [needsTransfer]
+
+/-- Theorems.DeleteOptIn — without `--delete` the delete set is empty. -/
+def deleteSet (withDelete : Bool) (candidates : List String) : List String :=
+  if withDelete then candidates else []
+
+theorem DeleteOptIn (candidates : List String) :
+    deleteSet false candidates = [] := by
+  rfl
+
+end ProvableContracts.Copia

--- a/src/bin/copia/dir_sync.rs
+++ b/src/bin/copia/dir_sync.rs
@@ -1,92 +1,16 @@
-//! Recursive directory sync orchestration (push local->remote, pull remote->local).
+//! Low-level directory-transfer primitives shared by the incremental sync
+//! orchestrator (`incremental.rs`): remote->local streaming, local dir creation,
+//! and the parallel-transfer progress counters. The orchestration itself (quick
+//! check, planning, atomic delivery, delete, dry-run) lives in `incremental.rs`.
 
+use super::transfer::format_bytes;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
-use tokio::sync::Semaphore;
 use tracing::instrument;
 
-use super::transfer::{
-    collect_dirs, compute_total_size, create_remote_dirs, discover_local_files, format_bytes,
-    join_handles, transfer_file_to_remote, transfer_speed,
-};
-use super::FileLocation;
-use copia::async_sync::AsyncCopiaSync;
-
-#[instrument(skip(source, dest, block_size))]
-pub async fn run_sync_recursive(
-    source: FileLocation,
-    dest: FileLocation,
-    block_size: usize,
-    jobs: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    match (&source, &dest) {
-        (FileLocation::Local(local_src), FileLocation::Remote { host, path }) => {
-            // GH-17: Warn that --block-size is not yet used for remote recursive sync
-            if block_size != 4096 {
-                eprintln!("Warning: --block-size is not yet implemented for remote recursive sync. Using default.");
-            }
-            run_sync_dir(TransferDir::Push, host, path, local_src, jobs, verbose).await
-        }
-        (FileLocation::Local(local_src), FileLocation::Local(local_dest)) => {
-            run_sync_dir_local_to_local(local_src, local_dest, block_size, jobs, verbose).await
-        }
-        (FileLocation::Remote { host, path }, FileLocation::Local(local_dest)) => {
-            // GH-17: --block-size not yet used for remote recursive sync.
-            if block_size != 4096 {
-                eprintln!("Warning: --block-size is not yet implemented for remote recursive sync. Using default.");
-            }
-            run_sync_dir(TransferDir::Pull, host, path, local_dest, jobs, verbose).await
-        }
-        _ => Err("Recursive sync supports local->remote, local->local, and remote->local (not remote->remote)".into()),
-    }
-}
-
-/// Discover all files under a remote directory tree via SSH `find`.
-/// Returns paths relative to `remote_root`, NUL-delimited so filenames with
-/// spaces/newlines are handled. Mirror of `discover_local_files` over SSH.
-async fn discover_remote_files(
-    host: &str,
-    remote_root: &str,
-) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
-    let escaped = remote_root.replace('\\', "\\\\").replace('\'', "\\'");
-    let output = tokio::process::Command::new("ssh")
-        .arg(host)
-        .arg(format!("cd $'{escaped}' && find . -type f -print0"))
-        .output()
-        .await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(
-            format!("Failed to list remote files under {host}:{remote_root}: {stderr}").into(),
-        );
-    }
-    Ok(parse_remote_find_output(&output.stdout))
-}
-
-/// Parse `find . -type f -print0` output (NUL-delimited, "./"-prefixed) into
-/// sorted relative paths. Factored out for unit testing.
-fn parse_remote_find_output(stdout: &[u8]) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    for entry in stdout.split(|&b| b == 0) {
-        if entry.is_empty() {
-            continue;
-        }
-        let s = String::from_utf8_lossy(entry);
-        // `find .` prints "./rel/path" — strip the leading "./".
-        let rel = s.strip_prefix("./").unwrap_or(&s);
-        if !rel.is_empty() {
-            files.push(PathBuf::from(rel));
-        }
-    }
-    files.sort();
-    files
-}
-
-/// Create the local directory structure for a pulled tree.
-fn create_local_dirs(
+/// Create the local directory structure for a synced tree (idempotent).
+pub fn create_local_dirs(
     local_root: &Path,
     dirs: &[PathBuf],
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -97,10 +21,11 @@ fn create_local_dirs(
     Ok(())
 }
 
-/// Transfer a single file remote->local via SSH streaming.
-/// Streams `ssh host "cat file"` straight to disk — never buffers the whole
-/// file in memory (the RAG index.json is >1 GiB). Returns bytes written.
-async fn transfer_file_from_remote(
+/// Stream `ssh host "cat remote_path"` straight to `local_path` — never buffers
+/// the whole file (the RAG index.json is >1 GiB). The caller is responsible for
+/// atomic delivery (transfer to a temp path, then rename). Returns bytes written.
+#[instrument(skip(local_path), fields(host, remote_path))]
+pub async fn transfer_file_from_remote(
     host: &str,
     remote_path: &str,
     local_path: &Path,
@@ -140,171 +65,9 @@ async fn transfer_file_from_remote(
     Ok(written)
 }
 
-/// Direction of a recursive directory transfer.
-#[derive(Clone, Copy, Debug)]
-enum TransferDir {
-    /// local -> remote (push)
-    Push,
-    /// remote -> local (pull)
-    Pull,
-}
-
-/// Spawn parallel per-file transfers for a directory tree, in either direction.
-/// Both directions compute the same local/remote paths and share identical
-/// progress/error handling — only the per-file transfer call differs.
-fn spawn_dir_transfers(
-    files: &[PathBuf],
-    dir: TransferDir,
-    host: &str,
-    remote_root: &str,
-    local_root: &Path,
-    semaphore: &Arc<Semaphore>,
-    progress: &TransferProgress,
-) -> Vec<tokio::task::JoinHandle<()>> {
-    let mut handles = Vec::with_capacity(files.len());
-
-    for rel_path in files {
-        let remote_file = format!("{}/{}", remote_root, rel_path.display());
-        let local_file = local_root.join(rel_path);
-        let host = host.to_string();
-        let sem = Arc::clone(semaphore);
-        let prog = progress.clone();
-        let rel_display = rel_path.display().to_string();
-
-        let handle = tokio::spawn(async move {
-            let _permit = sem.acquire().await;
-            match transfer_by_dir(dir, &host, &remote_file, &local_file).await {
-                Ok(size) => prog.record_ok(size),
-                Err(e) => prog.record_err(&rel_display, &e),
-            }
-        });
-        handles.push(handle);
-    }
-    handles
-}
-
-/// Recursively sync a directory tree in either direction: push (local->remote)
-/// or pull (remote->local). The direction selects discovery, destination-dir
-/// creation, and the per-file transfer; discover/collect/spawn/report are shared.
-#[allow(clippy::cast_possible_truncation)]
-#[instrument(skip(local_root), fields(host, remote_root))]
-async fn run_sync_dir(
-    dir: TransferDir,
-    host: &str,
-    remote_root: &str,
-    local_root: &Path,
-    jobs: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let start = Instant::now();
-    let (src_desc, dst_desc) = match dir {
-        TransferDir::Push => (
-            local_root.display().to_string(),
-            format!("{host}:{remote_root}"),
-        ),
-        TransferDir::Pull => (
-            format!("{host}:{remote_root}"),
-            local_root.display().to_string(),
-        ),
-    };
-
-    eprintln!("Discovering files in {src_desc}...");
-    let files = match dir {
-        TransferDir::Push => discover_local_files(local_root)?,
-        TransferDir::Pull => discover_remote_files(host, remote_root).await?,
-    };
-    if files.is_empty() {
-        eprintln!("No files found.");
-        return Ok(());
-    }
-
-    let dirs = collect_dirs(&files);
-    match dir {
-        // Only the local side knows file sizes up front.
-        TransferDir::Push => eprintln!(
-            "Found {} files ({}) across {} directories",
-            files.len(),
-            format_bytes(compute_total_size(local_root, &files)),
-            dirs.len()
-        ),
-        TransferDir::Pull => {
-            eprintln!(
-                "Found {} files across {} directories",
-                files.len(),
-                dirs.len()
-            );
-        }
-    }
-
-    match dir {
-        TransferDir::Push => {
-            eprintln!("Creating remote directory structure...");
-            create_remote_dirs(host, remote_root, &dirs).await?;
-        }
-        TransferDir::Pull => {
-            eprintln!("Creating local directory structure...");
-            create_local_dirs(local_root, &dirs)?;
-        }
-    }
-
-    eprintln!("Transferring with {jobs} parallel jobs...");
-    let semaphore = Arc::new(Semaphore::new(jobs));
-    let progress = TransferProgress::new(files.len() as u64);
-
-    let handles = spawn_dir_transfers(
-        &files,
-        dir,
-        host,
-        remote_root,
-        local_root,
-        &semaphore,
-        &progress,
-    );
-    join_handles(handles).await;
-
-    report_parallel_transfer(start, &progress, &src_desc, &dst_desc, jobs, verbose)
-}
-
-/// Shared completion report + result for a parallel directory transfer
-/// (both push and pull). Deduplicates the identical tail of the
-/// local->remote and remote->local paths.
-fn report_parallel_transfer(
-    start: Instant,
-    progress: &TransferProgress,
-    src_desc: &str,
-    dst_desc: &str,
-    jobs: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let elapsed = start.elapsed();
-    let total_tx = progress.bytes_transferred.load(Ordering::Relaxed);
-    let done_count = progress.files_done.load(Ordering::Relaxed);
-    let fail_count = progress.files_failed.load(Ordering::Relaxed);
-
-    println!("\nComplete: {done_count} files synced, {fail_count} failed");
-    println!(
-        "Transferred {} in {:.1}s ({}/s)",
-        format_bytes(total_tx),
-        elapsed.as_secs_f64(),
-        format_bytes(transfer_speed(total_tx, elapsed))
-    );
-
-    if verbose {
-        eprintln!("Source: {src_desc}");
-        eprintln!("Destination: {dst_desc}");
-        eprintln!("Jobs: {jobs}");
-    }
-
-    if fail_count > 0 {
-        Err(format!("{fail_count} files failed to transfer").into())
-    } else {
-        Ok(())
-    }
-}
-
-/// Shared progress counters for parallel transfer operations.
+/// Shared progress counters for parallel transfers (push/pull/local).
 #[derive(Clone)]
-struct TransferProgress {
+pub struct TransferProgress {
     bytes_transferred: Arc<AtomicU64>,
     files_done: Arc<AtomicU64>,
     files_failed: Arc<AtomicU64>,
@@ -312,7 +75,7 @@ struct TransferProgress {
 }
 
 impl TransferProgress {
-    fn new(total_files: u64) -> Self {
+    pub fn new(total_files: u64) -> Self {
         Self {
             bytes_transferred: Arc::new(AtomicU64::new(0)),
             files_done: Arc::new(AtomicU64::new(0)),
@@ -322,7 +85,7 @@ impl TransferProgress {
     }
 
     /// Record a successful transfer + emit a periodic progress line.
-    fn record_ok(&self, size: u64) {
+    pub fn record_ok(&self, size: u64) {
         self.bytes_transferred.fetch_add(size, Ordering::Relaxed);
         let n = self.files_done.fetch_add(1, Ordering::Relaxed) + 1;
         if n % 50 == 0 || n == self.total_files {
@@ -336,173 +99,46 @@ impl TransferProgress {
     }
 
     /// Record a failed transfer.
-    fn record_err(&self, rel_display: &str, err: &str) {
+    pub fn record_err(&self, rel_display: &str, err: &str) {
         self.files_failed.fetch_add(1, Ordering::Relaxed);
         eprintln!("  FAILED {rel_display}: {err}");
     }
-}
 
-/// Transfer one file in the given direction (push local->remote, pull remote->local).
-async fn transfer_by_dir(
-    dir: TransferDir,
-    host: &str,
-    remote_file: &str,
-    local_file: &Path,
-) -> Result<u64, String> {
-    match dir {
-        TransferDir::Push => transfer_file_to_remote(local_file, host, remote_file).await,
-        TransferDir::Pull => transfer_file_from_remote(host, remote_file, local_file).await,
+    pub fn bytes(&self) -> u64 {
+        self.bytes_transferred.load(Ordering::Relaxed)
+    }
+    pub fn done(&self) -> u64 {
+        self.files_done.load(Ordering::Relaxed)
+    }
+    pub fn failed(&self) -> u64 {
+        self.files_failed.load(Ordering::Relaxed)
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
-#[instrument(skip(local_src, local_dest))]
-async fn run_sync_dir_local_to_local(
-    local_src: &Path,
-    local_dest: &Path,
-    block_size: usize,
-    jobs: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let start = Instant::now();
-
-    eprintln!("Discovering files in {}...", local_src.display());
-    let files = discover_local_files(local_src)?;
-    if files.is_empty() {
-        eprintln!("No files found.");
-        return Ok(());
-    }
-
-    let total_size = compute_total_size(local_src, &files);
-    eprintln!("Found {} files ({})", files.len(), format_bytes(total_size));
-
-    // Create directory structure
-    std::fs::create_dir_all(local_dest)?;
-    for dir in collect_dirs(&files) {
-        std::fs::create_dir_all(local_dest.join(dir))?;
-    }
-
-    // GH-17: Use user-provided block_size instead of hardcoded 2048
-    let sync = Arc::new(AsyncCopiaSync::with_block_size(block_size));
-    let semaphore = Arc::new(Semaphore::new(jobs));
-    let progress = TransferProgress::new(files.len() as u64);
-
-    let handles =
-        spawn_local_transfers(&files, local_src, local_dest, &sync, &semaphore, &progress);
-
-    join_handles(handles).await;
-
-    let elapsed = start.elapsed();
-    let total_tx = progress.bytes_transferred.load(Ordering::Relaxed);
-
-    println!(
-        "\nComplete: {} files synced",
-        progress.files_done.load(Ordering::Relaxed)
-    );
-    println!(
-        "Transferred {} in {:.1}s ({}/s)",
-        format_bytes(total_tx),
-        elapsed.as_secs_f64(),
-        format_bytes(transfer_speed(total_tx, elapsed))
-    );
-
-    if verbose {
-        eprintln!("Source: {}", local_src.display());
-        eprintln!("Destination: {}", local_dest.display());
-    }
-
-    Ok(())
-}
-
-/// Spawn parallel local sync tasks for each file.
-fn spawn_local_transfers(
-    files: &[PathBuf],
-    local_src: &Path,
-    local_dest: &Path,
-    sync: &Arc<AsyncCopiaSync>,
-    semaphore: &Arc<Semaphore>,
-    progress: &TransferProgress,
-) -> Vec<tokio::task::JoinHandle<()>> {
-    let mut handles = Vec::with_capacity(files.len());
-    let total_files = progress.total_files;
-
-    for rel_path in files {
-        let src_file = local_src.join(rel_path);
-        let dst_file = local_dest.join(rel_path);
-        let sem = Arc::clone(semaphore);
-        let bytes_tx = Arc::clone(&progress.bytes_transferred);
-        let done = Arc::clone(&progress.files_done);
-        let sync = Arc::clone(sync);
-        let rel_display = rel_path.display().to_string();
-
-        let handle = tokio::spawn(async move {
-            let _permit = sem.acquire().await;
-            match sync.sync_files(&src_file, &dst_file).await {
-                Ok(result) => {
-                    bytes_tx.fetch_add(result.source_size, Ordering::Relaxed);
-                    let n = done.fetch_add(1, Ordering::Relaxed) + 1;
-                    if n % 100 == 0 || n == total_files {
-                        eprintln!("  [{n}/{total_files}] files synced");
-                    }
-                }
-                Err(e) => {
-                    eprintln!("  FAILED {rel_display}: {e}");
-                }
-            }
-        });
-        handles.push(handle);
-    }
-
-    handles
-}
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
-mod remote_pull_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn parse_find_strips_dot_slash_and_sorts() {
-        // `find . -type f -print0` output: NUL-delimited, "./"-prefixed.
-        let out = b"./a.txt\0./sub/b.txt\0./sub/deep/big.bin\0";
-        let got = parse_remote_find_output(out);
-        assert_eq!(
-            got,
-            vec![
-                PathBuf::from("a.txt"),
-                PathBuf::from("sub/b.txt"),
-                PathBuf::from("sub/deep/big.bin"),
-            ],
-            "must strip ./ and return sorted relative paths"
-        );
-    }
-
-    #[test]
-    fn parse_find_handles_empty_and_spaces() {
-        // Trailing NUL → empty final entry (must be skipped); spaces preserved.
-        let out = b"./with space.txt\0";
-        assert_eq!(
-            parse_remote_find_output(out),
-            vec![PathBuf::from("with space.txt")]
-        );
-        assert!(
-            parse_remote_find_output(b"").is_empty(),
-            "empty listing → no files"
-        );
-        assert!(
-            parse_remote_find_output(b"\0\0").is_empty(),
-            "only NULs → no files"
-        );
-    }
-
-    #[test]
-    fn create_local_dirs_builds_nested_tree() {
+    fn create_local_dirs_builds_nested_tree_idempotently() {
         let tmp = std::env::temp_dir().join(format!("copia-pull-dirs-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         let dirs = vec![PathBuf::from("sub"), PathBuf::from("sub/deep")];
         create_local_dirs(&tmp, &dirs).expect("create dirs");
         assert!(tmp.join("sub/deep").is_dir(), "nested dir must exist");
-        // Idempotent: a second call must not fail.
         create_local_dirs(&tmp, &dirs).expect("idempotent re-create");
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn progress_counters_track_ok_err_and_bytes() {
+        let p = TransferProgress::new(3);
+        p.record_ok(100);
+        p.record_ok(50);
+        p.record_err("bad", "boom");
+        assert_eq!(p.done(), 2);
+        assert_eq!(p.failed(), 1);
+        assert_eq!(p.bytes(), 150);
     }
 }

--- a/src/bin/copia/incremental.rs
+++ b/src/bin/copia/incremental.rs
@@ -1,0 +1,381 @@
+//! Incremental recursive sync — the rsync-style quick check (skip files whose
+//! size AND mtime match), atomic temp-file+rename delivery, mtime preservation,
+//! `--delete` mirroring, `--exclude` filtering, and `--dry-run` — across all
+//! three directions (push local->remote, pull remote->local, local->local).
+//!
+//! Built on `plan` (pure diff) + `meta` (both-sides metadata) + the `dir_sync`
+//! and `transfer` primitives. This is the L1 foundation the bidirectional (L2)
+//! reconciler and the hub daemon (L3) build on: both start from the same
+//! `MetaMap` diff and reuse atomic delivery for concurrency-safe writes.
+
+use super::dir_sync::{create_local_dirs, transfer_file_from_remote, TransferProgress};
+use super::meta::{discover_local_with_meta, discover_remote_with_meta, set_local_mtime};
+use super::plan::{build_plan, MetaMap, SyncPlan};
+use super::transfer::{
+    collect_dirs, create_remote_dirs, format_bytes, join_handles, transfer_file_to_remote,
+    transfer_speed,
+};
+use super::FileLocation;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::Semaphore;
+
+/// Knobs for one incremental sync run.
+pub struct SyncOptions {
+    pub jobs: usize,
+    pub verbose: bool,
+    pub dry_run: bool,
+    pub delete: bool,
+    pub excludes: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum Dir {
+    Push,
+    Pull,
+}
+
+/// Entry point: resolve the direction from the endpoints and run the plan.
+pub async fn run_sync_recursive(
+    source: FileLocation,
+    dest: FileLocation,
+    opts: SyncOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match (source, dest) {
+        (FileLocation::Local(local), FileLocation::Remote { host, path }) => {
+            run_remote(Dir::Push, &host, &path, &local, &opts).await
+        }
+        (FileLocation::Remote { host, path }, FileLocation::Local(local)) => {
+            run_remote(Dir::Pull, &host, &path, &local, &opts).await
+        }
+        (FileLocation::Local(from), FileLocation::Local(to)) => run_local(&from, &to, &opts).await,
+        _ => Err("Recursive sync supports local->remote, local->local, and remote->local (not remote->remote)".into()),
+    }
+}
+
+/// Append `.copia-tmp` to a path (unique per destination; never collides the way
+/// `with_extension` would). The atomic-delivery staging name.
+fn tmp_path(dst: &Path) -> PathBuf {
+    let mut s = dst.as_os_str().to_owned();
+    s.push(".copia-tmp");
+    PathBuf::from(s)
+}
+
+/// Emit the quick-check summary; in dry-run also list every planned action.
+fn print_plan(plan: &SyncPlan, dry_run: bool) {
+    eprintln!(
+        "Plan: {} to transfer, {} unchanged (skipped), {} to delete",
+        plan.transfer.len(),
+        plan.skipped,
+        plan.delete.len()
+    );
+    if dry_run {
+        for p in &plan.transfer {
+            println!("send   {}", p.display());
+        }
+        for p in &plan.delete {
+            println!("delete {}", p.display());
+        }
+        println!("(dry run) nothing was modified");
+    }
+}
+
+/// Final report; errors if any file failed to transfer (non-zero exit).
+fn report(
+    start: Instant,
+    progress: &TransferProgress,
+    plan: &SyncPlan,
+    src_desc: &str,
+    dst_desc: &str,
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let elapsed = start.elapsed();
+    let tx = progress.bytes();
+    println!(
+        "\nComplete: {} sent, {} skipped, {} deleted, {} failed",
+        progress.done(),
+        plan.skipped,
+        plan.delete.len(),
+        progress.failed()
+    );
+    println!(
+        "Transferred {} in {:.1}s ({}/s)",
+        format_bytes(tx),
+        elapsed.as_secs_f64(),
+        format_bytes(transfer_speed(tx, elapsed))
+    );
+    if verbose {
+        eprintln!("{src_desc} -> {dst_desc}");
+    }
+    if progress.failed() > 0 {
+        return Err(format!("{} file(s) failed to transfer", progress.failed()).into());
+    }
+    Ok(())
+}
+
+#[allow(clippy::cast_possible_truncation)]
+async fn run_remote(
+    dir: Dir,
+    host: &str,
+    remote_root: &str,
+    local_root: &Path,
+    opts: &SyncOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = Instant::now();
+    let (src_desc, dst_desc) = match dir {
+        Dir::Push => (
+            local_root.display().to_string(),
+            format!("{host}:{remote_root}"),
+        ),
+        Dir::Pull => (
+            format!("{host}:{remote_root}"),
+            local_root.display().to_string(),
+        ),
+    };
+    eprintln!("Scanning {src_desc} and {dst_desc}...");
+
+    // Source drives transfers; destination drives skip + delete. A missing dest
+    // (first sync) yields an empty map, so every source file is new.
+    // Resolve each `?` into a binding BEFORE any await so no error-carrying
+    // temporary is held across it (keeps the future `Send`).
+    let (src_meta, dst_meta): (MetaMap, MetaMap) = match dir {
+        Dir::Push => {
+            let local = discover_local_with_meta(local_root)?;
+            let remote = discover_remote_with_meta(host, remote_root)
+                .await
+                .unwrap_or_default();
+            (local, remote)
+        }
+        Dir::Pull => {
+            let remote = discover_remote_with_meta(host, remote_root).await?;
+            let local = discover_local_with_meta(local_root).unwrap_or_default();
+            (remote, local)
+        }
+    };
+    // Empty source short-circuits (unless mirroring, where empty source is a
+    // legitimate "delete everything on the destination").
+    if src_meta.is_empty() && !opts.delete {
+        eprintln!("No files found.");
+        return Ok(());
+    }
+    let plan = build_plan(&src_meta, &dst_meta, &opts.excludes, opts.delete);
+    print_plan(&plan, opts.dry_run);
+    if opts.dry_run {
+        return Ok(());
+    }
+    if plan.transfer.is_empty() && plan.delete.is_empty() {
+        println!("Already up to date ({} files).", src_meta.len());
+        return Ok(());
+    }
+
+    let dirs = collect_dirs(&plan.transfer);
+    match dir {
+        Dir::Push => create_remote_dirs(host, remote_root, &dirs).await?,
+        Dir::Pull => create_local_dirs(local_root, &dirs)?,
+    }
+
+    let semaphore = Arc::new(Semaphore::new(opts.jobs));
+    let progress = TransferProgress::new(plan.transfer.len() as u64);
+    let mut handles = Vec::with_capacity(plan.transfer.len());
+    for rel in &plan.transfer {
+        let mtime = src_meta.get(rel).map(|m| m.mtime);
+        let remote_file = format!("{}/{}", remote_root, rel.display());
+        let local_file = local_root.join(rel);
+        let host = host.to_string();
+        let sem = Arc::clone(&semaphore);
+        let prog = progress.clone();
+        let rel_disp = rel.display().to_string();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await;
+            let res = match dir {
+                Dir::Push => transfer_file_to_remote(&local_file, &host, &remote_file, mtime).await,
+                Dir::Pull => deliver_pull(&host, &remote_file, &local_file, mtime).await,
+            };
+            match res {
+                Ok(size) => prog.record_ok(size),
+                Err(e) => prog.record_err(&rel_disp, &e),
+            }
+        }));
+    }
+    join_handles(handles).await;
+
+    if !plan.delete.is_empty() {
+        apply_remote_deletes(dir, host, remote_root, local_root, &plan.delete).await;
+    }
+    report(start, &progress, &plan, &src_desc, &dst_desc, opts.verbose)
+}
+
+/// Atomic pull: stream to a `.copia-tmp` sibling, rename into place, set mtime.
+async fn deliver_pull(
+    host: &str,
+    remote_file: &str,
+    local_dest: &Path,
+    mtime: Option<i64>,
+) -> Result<u64, String> {
+    let tmp = tmp_path(local_dest);
+    let size = transfer_file_from_remote(host, remote_file, &tmp).await?;
+    tokio::fs::rename(&tmp, local_dest)
+        .await
+        .map_err(|e| format!("rename {}: {e}", local_dest.display()))?;
+    if let Some(t) = mtime {
+        let _ = set_local_mtime(local_dest, t);
+    }
+    Ok(size)
+}
+
+/// Delete the mirror's stale files. Pull deletes locally; push batches one
+/// `xargs rm` over SSH.
+async fn apply_remote_deletes(
+    dir: Dir,
+    host: &str,
+    remote_root: &str,
+    local_root: &Path,
+    dels: &[PathBuf],
+) {
+    match dir {
+        Dir::Pull => {
+            for rel in dels {
+                let _ = std::fs::remove_file(local_root.join(rel));
+            }
+        }
+        Dir::Push => {
+            use std::fmt::Write as _;
+            use tokio::io::AsyncWriteExt;
+            let mut list = String::new();
+            for rel in dels {
+                let _ = writeln!(list, "{}/{}", remote_root, rel.display());
+            }
+            if let Ok(mut child) = tokio::process::Command::new("ssh")
+                .arg(host)
+                .arg("xargs -d '\\n' rm -f --")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+            {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.write_all(list.as_bytes()).await;
+                    drop(stdin);
+                }
+                let _ = child.wait_with_output().await;
+            }
+        }
+    }
+    eprintln!("Deleted {} stale file(s) on the destination", dels.len());
+}
+
+#[allow(clippy::cast_possible_truncation)]
+async fn run_local(
+    src: &Path,
+    dst: &Path,
+    opts: &SyncOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = Instant::now();
+    eprintln!("Scanning {} and {}...", src.display(), dst.display());
+    let src_meta = discover_local_with_meta(src)?;
+    if src_meta.is_empty() && !opts.delete {
+        eprintln!("No files found.");
+        return Ok(());
+    }
+    let dst_meta = discover_local_with_meta(dst).unwrap_or_default();
+    let plan = build_plan(&src_meta, &dst_meta, &opts.excludes, opts.delete);
+    print_plan(&plan, opts.dry_run);
+    if opts.dry_run {
+        return Ok(());
+    }
+    if plan.transfer.is_empty() && plan.delete.is_empty() {
+        println!("Already up to date ({} files).", src_meta.len());
+        return Ok(());
+    }
+
+    create_local_dirs(dst, &collect_dirs(&plan.transfer))?;
+    let semaphore = Arc::new(Semaphore::new(opts.jobs));
+    let progress = TransferProgress::new(plan.transfer.len() as u64);
+    let mut handles = Vec::with_capacity(plan.transfer.len());
+    for rel in &plan.transfer {
+        let mtime = src_meta.get(rel).map(|m| m.mtime);
+        let s = src.join(rel);
+        let d = dst.join(rel);
+        let sem = Arc::clone(&semaphore);
+        let prog = progress.clone();
+        let rel_disp = rel.display().to_string();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await;
+            match deliver_local(&s, &d, mtime).await {
+                Ok(size) => prog.record_ok(size),
+                Err(e) => prog.record_err(&rel_disp, &e),
+            }
+        }));
+    }
+    join_handles(handles).await;
+
+    if !plan.delete.is_empty() {
+        for rel in &plan.delete {
+            let _ = std::fs::remove_file(dst.join(rel));
+        }
+        eprintln!("Deleted {} stale file(s)", plan.delete.len());
+    }
+    report(
+        start,
+        &progress,
+        &plan,
+        &src.display().to_string(),
+        &dst.display().to_string(),
+        opts.verbose,
+    )
+}
+
+/// Atomic local copy: copy to a `.copia-tmp` sibling, rename, set mtime.
+async fn deliver_local(src: &Path, dst: &Path, mtime: Option<i64>) -> Result<u64, String> {
+    let tmp = tmp_path(dst);
+    let size = tokio::fs::copy(src, &tmp)
+        .await
+        .map_err(|e| format!("copy {}: {e}", src.display()))?;
+    tokio::fs::rename(&tmp, dst)
+        .await
+        .map_err(|e| format!("rename {}: {e}", dst.display()))?;
+    if let Some(t) = mtime {
+        let _ = set_local_mtime(dst, t);
+    }
+    Ok(size)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmp_path_appends_suffix_without_colliding() {
+        assert_eq!(
+            tmp_path(Path::new("a/b.json")),
+            PathBuf::from("a/b.json.copia-tmp")
+        );
+        // distinct sources -> distinct temp names (with_extension would collide)
+        assert_ne!(
+            tmp_path(Path::new("a/x.json")),
+            tmp_path(Path::new("a/x.txt"))
+        );
+    }
+
+    #[tokio::test]
+    async fn deliver_local_is_atomic_and_preserves_mtime() {
+        let base = std::env::temp_dir().join(format!("copia-incr-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let src = base.join("s");
+        let dst = base.join("d");
+        std::fs::write(&src, b"payload").unwrap();
+        let n = deliver_local(&src, &dst, Some(1_600_000_000))
+            .await
+            .unwrap();
+        assert_eq!(n, 7);
+        assert_eq!(std::fs::read(&dst).unwrap(), b"payload");
+        // no temp file left behind
+        assert!(!tmp_path(&dst).exists());
+        let m = discover_local_with_meta(&base).unwrap();
+        assert_eq!(m[&PathBuf::from("d")].mtime, 1_600_000_000);
+        std::fs::remove_dir_all(&base).ok();
+    }
+}

--- a/src/bin/copia/main.rs
+++ b/src/bin/copia/main.rs
@@ -1,6 +1,6 @@
 //! Copia CLI - rsync-style file synchronization.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
@@ -82,6 +82,20 @@ enum Commands {
         /// Show verbose output
         #[arg(short, long)]
         verbose: bool,
+
+        /// Show what would change without transferring or deleting anything
+        #[arg(short = 'n', long)]
+        dry_run: bool,
+
+        /// Mirror: delete destination files that no longer exist in the source
+        #[arg(long)]
+        delete: bool,
+
+        /// Skip paths matching GLOB (repeatable). Slash-free patterns match any
+        /// path component (e.g. `target`, `*.tmp`); patterns with `/` match the
+        /// whole relative path.
+        #[arg(long = "exclude", value_name = "GLOB")]
+        excludes: Vec<String>,
     },
 
     /// Generate signature for a file
@@ -181,11 +195,21 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             recursive,
             jobs,
             verbose,
+            dry_run,
+            delete,
+            excludes,
         } => {
             let src_loc = FileLocation::parse(&source);
             let dest_loc = FileLocation::parse(&dest);
             if recursive {
-                run_sync_recursive(src_loc, dest_loc, block_size, jobs, verbose).await
+                let opts = SyncOptions {
+                    jobs,
+                    verbose,
+                    dry_run,
+                    delete,
+                    excludes,
+                };
+                run_sync_recursive(src_loc, dest_loc, opts).await
             } else {
                 run_sync(src_loc, dest_loc, block_size, verbose).await
             }
@@ -209,171 +233,13 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 mod dir_sync;
+mod incremental;
+mod meta;
+mod plan;
+mod single_sync;
 mod transfer;
-use dir_sync::run_sync_recursive;
-use transfer::{format_bytes, transfer_file_to_remote};
-
-// ── Single-file sync ──────────────────────────────────────────────────
-
-#[instrument(skip(source, dest))]
-async fn run_sync(
-    source: FileLocation,
-    dest: FileLocation,
-    block_size: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    validate_block_size(block_size)?;
-
-    match (&source, &dest) {
-        (FileLocation::Local(local_src), FileLocation::Local(local_dest)) => {
-            run_sync_local_to_local(local_src, local_dest, block_size, verbose).await
-        }
-        (FileLocation::Local(local_src), FileLocation::Remote { host, path }) => {
-            run_sync_local_to_remote(local_src, host, path, block_size, verbose).await
-        }
-        (FileLocation::Remote { host, path }, FileLocation::Local(local_dest)) => {
-            run_sync_remote_to_local(host, path, local_dest, block_size, verbose).await
-        }
-        (
-            FileLocation::Remote {
-                host: src_host,
-                path: src_path,
-            },
-            FileLocation::Remote {
-                host: dst_host,
-                path: dst_path,
-            },
-        ) => {
-            Err(format!(
-                "Remote-to-remote sync not yet supported: {src_host}:{src_path} -> {dst_host}:{dst_path}"
-            )
-            .into())
-        }
-    }
-}
-
-#[instrument(skip(source, dest))]
-async fn run_sync_local_to_local(
-    source: &PathBuf,
-    dest: &PathBuf,
-    block_size: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let sync = AsyncCopiaSync::with_block_size(block_size);
-
-    if verbose {
-        eprintln!("Syncing {} -> {}", source.display(), dest.display());
-        eprintln!("Block size: {block_size}");
-    }
-
-    let result = sync.sync_files(source, dest).await?;
-
-    if verbose {
-        eprintln!("Source size: {} bytes", result.source_size);
-        eprintln!("Basis size: {} bytes", result.basis_size);
-        eprintln!("Bytes matched: {} bytes", result.bytes_matched);
-        eprintln!("Bytes literal: {} bytes", result.bytes_literal);
-        eprintln!(
-            "Compression ratio: {:.1}%",
-            result.compression_ratio() * 100.0
-        );
-        eprintln!(
-            "Bandwidth savings: {:.1}%",
-            result.bandwidth_savings() * 100.0
-        );
-    }
-
-    println!(
-        "Synced {} ({} bytes matched, {} bytes literal)",
-        dest.display(),
-        result.bytes_matched,
-        result.bytes_literal
-    );
-
-    Ok(())
-}
-
-#[instrument(skip(source, block_size), fields(host, remote_path))]
-async fn run_sync_local_to_remote(
-    source: &Path,
-    host: &str,
-    remote_path: &str,
-    block_size: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // GH-17: Warn that --block-size is not yet used for SSH transfers
-    if block_size != 4096 {
-        eprintln!("Warning: --block-size is not yet implemented for remote transfers. Using SSH streaming.");
-    }
-    if verbose {
-        eprintln!("Syncing {} -> {}:{}", source.display(), host, remote_path);
-    }
-
-    let size = transfer_file_to_remote(source, host, remote_path)
-        .await
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-
-    if verbose {
-        eprintln!("Transferred: {size} bytes");
-    }
-
-    println!(
-        "Synced {host}:{remote_path} ({} transferred)",
-        format_bytes(size)
-    );
-
-    Ok(())
-}
-
-#[instrument(skip(dest, block_size), fields(host, remote_path))]
-async fn run_sync_remote_to_local(
-    host: &str,
-    remote_path: &str,
-    dest: &PathBuf,
-    block_size: usize,
-    verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // GH-17: Warn that --block-size is not yet used for SSH transfers
-    if block_size != 4096 {
-        eprintln!("Warning: --block-size is not yet implemented for remote transfers. Using SSH streaming.");
-    }
-    use tokio::process::Command;
-
-    if verbose {
-        eprintln!("Syncing {}:{} -> {}", host, remote_path, dest.display());
-    }
-
-    let output = Command::new("ssh")
-        .arg(host)
-        .arg(format!(
-            "cat $'{}'",
-            remote_path.replace('\\', "\\\\").replace('\'', "\\'")
-        ))
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("SSH transfer failed: {stderr}").into());
-    }
-
-    let remote_data = output.stdout;
-    let remote_size = remote_data.len();
-
-    tokio::fs::write(dest, &remote_data).await?;
-
-    if verbose {
-        eprintln!("Remote size: {remote_size} bytes");
-    }
-
-    println!(
-        "Synced {} ({} transferred)",
-        dest.display(),
-        format_bytes(remote_size as u64)
-    );
-
-    Ok(())
-}
+use incremental::{run_sync_recursive, SyncOptions};
+use single_sync::run_sync;
 
 // ── Signature / Delta / Patch ─────────────────────────────────────────
 
@@ -475,7 +341,7 @@ async fn run_patch(
     Ok(())
 }
 
-fn validate_block_size(size: usize) -> Result<(), String> {
+pub(crate) fn validate_block_size(size: usize) -> Result<(), String> {
     if !size.is_power_of_two() {
         return Err(format!("Block size must be a power of 2, got {size}"));
     }

--- a/src/bin/copia/meta.rs
+++ b/src/bin/copia/meta.rs
@@ -1,0 +1,141 @@
+//! Filesystem + remote metadata discovery for the quick check, plus the mtime
+//! preservation helpers that keep it stable across runs.
+
+use super::plan::{FileMeta, MetaMap};
+use super::transfer::discover_local_files;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, UNIX_EPOCH};
+
+/// A std file mtime as whole epoch seconds (the quick-check granularity).
+fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(0))
+}
+
+/// Walk a local tree and stat every file into a `MetaMap` of relative paths.
+pub fn discover_local_with_meta(root: &Path) -> Result<MetaMap, Box<dyn std::error::Error>> {
+    let mut out = MetaMap::new();
+    for rel in discover_local_files(root)? {
+        if let Ok(meta) = std::fs::metadata(root.join(&rel)) {
+            out.insert(
+                rel,
+                FileMeta {
+                    size: meta.len(),
+                    mtime: mtime_secs(&meta),
+                },
+            );
+        }
+    }
+    Ok(out)
+}
+
+/// List a remote tree with size+mtime in one `find -printf` over SSH.
+pub async fn discover_remote_with_meta(
+    host: &str,
+    remote_root: &str,
+) -> Result<MetaMap, Box<dyn std::error::Error>> {
+    let escaped = remote_root.replace('\\', "\\\\").replace('\'', "\\'");
+    // %s size, %T@ mtime (float secs), %p path — TAB-separated, NUL-terminated.
+    let output = tokio::process::Command::new("ssh")
+        .arg(host)
+        .arg(format!(
+            "cd $'{escaped}' && find . -type f -printf '%s\\t%T@\\t%p\\0'"
+        ))
+        .output()
+        .await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to list {host}:{remote_root}: {stderr}").into());
+    }
+    Ok(parse_remote_meta_output(&output.stdout))
+}
+
+/// Parse NUL-terminated `size\tmtime\t./path` records into a `MetaMap`.
+pub fn parse_remote_meta_output(stdout: &[u8]) -> MetaMap {
+    let mut out = MetaMap::new();
+    for entry in stdout.split(|&b| b == 0) {
+        if entry.is_empty() {
+            continue;
+        }
+        let s = String::from_utf8_lossy(entry);
+        let mut parts = s.splitn(3, '\t');
+        let (Some(size), Some(mtime), Some(path)) = (parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        let Ok(size) = size.parse::<u64>() else {
+            continue;
+        };
+        // %T@ is "secs.nanos" — truncate to whole seconds.
+        let mtime = mtime
+            .split('.')
+            .next()
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(0);
+        let rel = path.strip_prefix("./").unwrap_or(path);
+        if !rel.is_empty() {
+            out.insert(PathBuf::from(rel), FileMeta { size, mtime });
+        }
+    }
+    out
+}
+
+/// Set a local file's mtime to `secs` epoch seconds (best-effort).
+pub fn set_local_mtime(path: &Path, secs: i64) -> std::io::Result<()> {
+    let t = UNIX_EPOCH + Duration::from_secs(u64::try_from(secs.max(0)).unwrap_or(0));
+    std::fs::File::options()
+        .write(true)
+        .open(path)?
+        .set_modified(t)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_meta_reads_size_mtime_path_and_truncates_subsecond() {
+        let raw = b"1024\t1700000000.500\t./a.txt\x00\t\t\x00512\t1699999999\t./sub/b.bin\0";
+        let m = parse_remote_meta_output(raw);
+        assert_eq!(m.len(), 2);
+        assert_eq!(
+            m[&PathBuf::from("a.txt")],
+            FileMeta {
+                size: 1024,
+                mtime: 1_700_000_000
+            }
+        );
+        assert_eq!(
+            m[&PathBuf::from("sub/b.bin")],
+            FileMeta {
+                size: 512,
+                mtime: 1_699_999_999
+            }
+        );
+    }
+
+    #[test]
+    fn parse_meta_skips_malformed_records() {
+        // missing fields / non-numeric size are dropped, not panicked on
+        let m = parse_remote_meta_output(b"notanumber\t123\t./x\0\0only-one-field\0");
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn discover_local_meta_and_set_mtime_roundtrip() {
+        let base = std::env::temp_dir().join(format!("copia-meta-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join("d")).unwrap();
+        std::fs::write(base.join("d/f"), b"hello").unwrap();
+        let m = discover_local_with_meta(&base).unwrap();
+        assert_eq!(m[&PathBuf::from("d/f")].size, 5);
+        // set + read back the mtime at 1s granularity
+        set_local_mtime(&base.join("d/f"), 1_600_000_000).unwrap();
+        let m2 = discover_local_with_meta(&base).unwrap();
+        assert_eq!(m2[&PathBuf::from("d/f")].mtime, 1_600_000_000);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}

--- a/src/bin/copia/plan.rs
+++ b/src/bin/copia/plan.rs
@@ -1,0 +1,278 @@
+//! Pure sync-planning — the rsync-style quick check, exclude globbing, and
+//! delete-set computation. Deliberately free of I/O so it is exhaustively
+//! unit-testable; `incremental.rs` supplies the metadata and executes the plan.
+
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+
+/// Minimal per-file metadata driving the quick check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FileMeta {
+    pub size: u64,
+    /// mtime as whole epoch seconds. Sub-second precision is unreliable across
+    /// `find -printf %T@` vs `SystemTime` and across filesystems, so the quick
+    /// check compares at 1-second granularity — exactly rsync's default posture.
+    pub mtime: i64,
+}
+
+/// A tree of relative paths to their metadata (sorted, for deterministic plans).
+pub type MetaMap = BTreeMap<PathBuf, FileMeta>;
+
+/// The diff of source vs destination that drives one sync run.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SyncPlan {
+    /// New or changed files to transfer (sorted).
+    pub transfer: Vec<PathBuf>,
+    /// Count of files skipped because size AND mtime matched the destination.
+    pub skipped: usize,
+    /// Destination files to remove (present on dest, absent from filtered
+    /// source) — populated only when delete is requested. Sorted.
+    pub delete: Vec<PathBuf>,
+}
+
+/// Quick check: a source file needs transfer when the destination lacks it, or
+/// its size or mtime differ. Excluded source paths are dropped entirely — never
+/// transferred, and (critically) never counted toward the delete set, so an
+/// `--exclude`d path on the destination is left untouched rather than deleted.
+pub fn build_plan(
+    src: &MetaMap,
+    dst: &MetaMap,
+    excludes: &[String],
+    with_delete: bool,
+) -> SyncPlan {
+    let mut plan = SyncPlan::default();
+    for (path, smeta) in src {
+        if is_excluded(path, excludes) {
+            continue;
+        }
+        if needs_transfer(*smeta, dst.get(path).copied()) {
+            plan.transfer.push(path.clone());
+        } else {
+            plan.skipped += 1;
+        }
+    }
+    if with_delete {
+        for path in dst.keys() {
+            if !src.contains_key(path) && !is_excluded(path, excludes) {
+                plan.delete.push(path.clone());
+            }
+        }
+    }
+    plan.transfer.sort();
+    plan.delete.sort();
+    plan
+}
+
+/// The per-file quick-check decision, factored out so it can be exhaustively
+/// model-checked (Kani, `plan-kani-001`): a source file must be transferred iff
+/// the destination lacks it, or its size or mtime differ. This is the single
+/// invariant the whole incremental engine rests on.
+#[must_use]
+pub fn needs_transfer(src: FileMeta, dst: Option<FileMeta>) -> bool {
+    dst.map_or(true, |d| src.size != d.size || src.mtime != d.mtime)
+}
+
+/// True if any exclude pattern matches the relative path. gitignore-style: a
+/// pattern with no `/` matches any single path *component* (so `target` or
+/// `*.tmp` prune anywhere in the tree, and a trailing slash like `target/` is
+/// accepted as the same); a pattern containing `/` matches the whole relative
+/// path as a glob.
+pub fn is_excluded(rel: &Path, excludes: &[String]) -> bool {
+    for pat in excludes {
+        let pat = pat.trim_end_matches('/');
+        if pat.is_empty() {
+            continue;
+        }
+        if pat.contains('/') {
+            if glob_match(pat, &rel.to_string_lossy()) {
+                return true;
+            }
+        } else {
+            for comp in rel.components() {
+                if let Component::Normal(c) = comp {
+                    if glob_match(pat, &c.to_string_lossy()) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Classic wildcard match with backtracking: `*` matches any run of characters,
+/// `?` matches exactly one. O(n·m) worst case, which is fine for path-length
+/// inputs. Slash-awareness is handled by the caller (per-component vs whole-path).
+pub fn glob_match(pat: &str, text: &str) -> bool {
+    let p: Vec<char> = pat.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star, mut mark) = (None, 0usize);
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == t[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            mark = ti;
+            pi += 1;
+        } else if let Some(s) = star {
+            pi = s + 1;
+            mark += 1;
+            ti = mark;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+/// L3 proof harnesses (Kani) for the pure quick-check decision. Run with
+/// `cargo kani`. These bound the `incremental-sync-v1` proof obligations to
+/// machine-checked proofs rather than tests alone.
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    /// plan-kani-001: a file is transferred iff it is new (no dest) or differs
+    /// in size or mtime; an identical file is NEVER re-transferred. Exhaustive
+    /// over all (size, mtime) pairs — the core skip guarantee.
+    #[kani::proof]
+    fn needs_transfer_iff_new_or_differing() {
+        let s = FileMeta {
+            size: kani::any(),
+            mtime: kani::any(),
+        };
+        // New destination (absent) always transfers.
+        assert!(needs_transfer(s, None));
+        // An identical destination is never re-transferred (the skip guarantee).
+        assert!(!needs_transfer(s, Some(s)));
+        // A present destination transfers iff size or mtime differ.
+        let d = FileMeta {
+            size: kani::any(),
+            mtime: kani::any(),
+        };
+        assert_eq!(
+            needs_transfer(s, Some(d)),
+            s.size != d.size || s.mtime != d.mtime
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn m(size: u64, mtime: i64) -> FileMeta {
+        FileMeta { size, mtime }
+    }
+
+    #[test]
+    fn needs_transfer_matches_the_quick_check_rule() {
+        assert!(needs_transfer(m(1, 1), None)); // new
+        assert!(!needs_transfer(m(1, 1), Some(m(1, 1)))); // identical -> skip
+        assert!(needs_transfer(m(2, 1), Some(m(1, 1)))); // size differs
+        assert!(needs_transfer(m(1, 2), Some(m(1, 1)))); // mtime differs
+    }
+    fn map(entries: &[(&str, u64, i64)]) -> MetaMap {
+        entries
+            .iter()
+            .map(|(p, s, t)| (PathBuf::from(p), m(*s, *t)))
+            .collect()
+    }
+
+    #[test]
+    fn glob_star_question_and_literal() {
+        assert!(glob_match("*.tmp", "foo.tmp"));
+        assert!(glob_match("*.tmp", ".tmp"));
+        assert!(!glob_match("*.tmp", "foo.txt"));
+        assert!(glob_match("a?c", "abc"));
+        assert!(!glob_match("a?c", "ac"));
+        assert!(glob_match("target", "target"));
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("a*b*c", "axxbyyc"));
+        assert!(!glob_match("a*b*c", "axxbyy"));
+        assert!(glob_match("", ""));
+        assert!(!glob_match("", "x"));
+    }
+
+    #[test]
+    fn exclude_matches_any_component_when_slashless() {
+        let ex = vec!["target".to_string(), "*.tmp".to_string()];
+        assert!(is_excluded(Path::new("target/debug/app"), &ex));
+        assert!(is_excluded(Path::new("crate/target/x"), &ex));
+        assert!(is_excluded(Path::new("build/out.tmp"), &ex));
+        assert!(!is_excluded(Path::new("src/main.rs"), &ex));
+    }
+
+    #[test]
+    fn exclude_trailing_slash_and_full_path_pattern() {
+        assert!(is_excluded(
+            Path::new("node_modules/x/y"),
+            &["node_modules/".to_string()]
+        ));
+        // slash-bearing pattern matches the whole relative path as a glob
+        assert!(is_excluded(
+            Path::new("a/b/c.log"),
+            &["a/*/c.log".to_string()]
+        ));
+        assert!(!is_excluded(
+            Path::new("a/b/c.log"),
+            &["a/c.log".to_string()]
+        ));
+        // empty patterns are ignored
+        assert!(!is_excluded(
+            Path::new("x"),
+            &[String::new(), "/".to_string()]
+        ));
+    }
+
+    #[test]
+    fn quick_check_skips_identical_transfers_changed_and_new() {
+        let src = map(&[
+            ("same", 10, 100),
+            ("changed_size", 20, 100),
+            ("changed_mtime", 10, 200),
+            ("new", 5, 100),
+        ]);
+        let dst = map(&[
+            ("same", 10, 100),
+            ("changed_size", 10, 100),
+            ("changed_mtime", 10, 100),
+        ]);
+        let plan = build_plan(&src, &dst, &[], false);
+        assert_eq!(plan.skipped, 1); // "same"
+        assert_eq!(
+            plan.transfer,
+            vec![
+                PathBuf::from("changed_mtime"),
+                PathBuf::from("changed_size"),
+                PathBuf::from("new")
+            ]
+        );
+        assert!(plan.delete.is_empty()); // delete not requested
+    }
+
+    #[test]
+    fn delete_set_is_dest_minus_source_and_honors_excludes() {
+        let src = map(&[("keep", 1, 1)]);
+        let dst = map(&[("keep", 1, 1), ("stale", 1, 1), ("target", 1, 1)]);
+        // without delete: nothing removed
+        assert!(build_plan(&src, &dst, &[], false).delete.is_empty());
+        // with delete: "stale" removed, but "target" is excluded => NOT deleted
+        let plan = build_plan(&src, &dst, &["target".to_string()], true);
+        assert_eq!(plan.delete, vec![PathBuf::from("stale")]);
+        assert_eq!(plan.skipped, 1); // "keep"
+    }
+
+    #[test]
+    fn excluded_source_file_is_never_transferred() {
+        let src = map(&[("keep.rs", 1, 1), ("junk.tmp", 1, 1)]);
+        let plan = build_plan(&src, &MetaMap::new(), &["*.tmp".to_string()], false);
+        assert_eq!(plan.transfer, vec![PathBuf::from("keep.rs")]);
+    }
+}

--- a/src/bin/copia/single_sync.rs
+++ b/src/bin/copia/single_sync.rs
@@ -1,0 +1,164 @@
+//! Single-file sync (non-recursive) across the three directions. The recursive
+//! path lives in `incremental.rs`; this handles one file at a time.
+
+use super::transfer::{format_bytes, transfer_file_to_remote};
+use super::{validate_block_size, FileLocation};
+use copia::async_sync::AsyncCopiaSync;
+use std::path::{Path, PathBuf};
+use tracing::instrument;
+
+#[instrument(skip(source, dest))]
+pub async fn run_sync(
+    source: FileLocation,
+    dest: FileLocation,
+    block_size: usize,
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    validate_block_size(block_size)?;
+
+    match (&source, &dest) {
+        (FileLocation::Local(local_src), FileLocation::Local(local_dest)) => {
+            run_sync_local_to_local(local_src, local_dest, block_size, verbose).await
+        }
+        (FileLocation::Local(local_src), FileLocation::Remote { host, path }) => {
+            run_sync_local_to_remote(local_src, host, path, block_size, verbose).await
+        }
+        (FileLocation::Remote { host, path }, FileLocation::Local(local_dest)) => {
+            run_sync_remote_to_local(host, path, local_dest, block_size, verbose).await
+        }
+        (
+            FileLocation::Remote {
+                host: src_host,
+                path: src_path,
+            },
+            FileLocation::Remote {
+                host: dst_host,
+                path: dst_path,
+            },
+        ) => Err(format!(
+            "Remote-to-remote sync not yet supported: {src_host}:{src_path} -> {dst_host}:{dst_path}"
+        )
+        .into()),
+    }
+}
+
+#[instrument(skip(source, dest))]
+async fn run_sync_local_to_local(
+    source: &PathBuf,
+    dest: &PathBuf,
+    block_size: usize,
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sync = AsyncCopiaSync::with_block_size(block_size);
+
+    if verbose {
+        eprintln!("Syncing {} -> {}", source.display(), dest.display());
+        eprintln!("Block size: {block_size}");
+    }
+
+    let result = sync.sync_files(source, dest).await?;
+
+    if verbose {
+        eprintln!("Source size: {} bytes", result.source_size);
+        eprintln!("Basis size: {} bytes", result.basis_size);
+        eprintln!("Bytes matched: {} bytes", result.bytes_matched);
+        eprintln!("Bytes literal: {} bytes", result.bytes_literal);
+        eprintln!(
+            "Compression ratio: {:.1}%",
+            result.compression_ratio() * 100.0
+        );
+        eprintln!(
+            "Bandwidth savings: {:.1}%",
+            result.bandwidth_savings() * 100.0
+        );
+    }
+
+    println!(
+        "Synced {} ({} bytes matched, {} bytes literal)",
+        dest.display(),
+        result.bytes_matched,
+        result.bytes_literal
+    );
+
+    Ok(())
+}
+
+#[instrument(skip(source, block_size), fields(host, remote_path))]
+async fn run_sync_local_to_remote(
+    source: &Path,
+    host: &str,
+    remote_path: &str,
+    block_size: usize,
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if block_size != 4096 {
+        eprintln!("Warning: --block-size is not yet implemented for remote transfers. Using SSH streaming.");
+    }
+    if verbose {
+        eprintln!("Syncing {} -> {}:{}", source.display(), host, remote_path);
+    }
+
+    let size = transfer_file_to_remote(source, host, remote_path, None)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    if verbose {
+        eprintln!("Transferred: {size} bytes");
+    }
+
+    println!(
+        "Synced {host}:{remote_path} ({} transferred)",
+        format_bytes(size)
+    );
+
+    Ok(())
+}
+
+#[instrument(skip(dest, block_size), fields(host, remote_path))]
+async fn run_sync_remote_to_local(
+    host: &str,
+    remote_path: &str,
+    dest: &PathBuf,
+    block_size: usize,
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if block_size != 4096 {
+        eprintln!("Warning: --block-size is not yet implemented for remote transfers. Using SSH streaming.");
+    }
+    use tokio::process::Command;
+
+    if verbose {
+        eprintln!("Syncing {}:{} -> {}", host, remote_path, dest.display());
+    }
+
+    let output = Command::new("ssh")
+        .arg(host)
+        .arg(format!(
+            "cat $'{}'",
+            remote_path.replace('\\', "\\\\").replace('\'', "\\'")
+        ))
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("SSH transfer failed: {stderr}").into());
+    }
+
+    let remote_data = output.stdout;
+    let remote_size = remote_data.len();
+
+    tokio::fs::write(dest, &remote_data).await?;
+
+    if verbose {
+        eprintln!("Remote size: {remote_size} bytes");
+    }
+
+    println!(
+        "Synced {} ({} transferred)",
+        dest.display(),
+        format_bytes(remote_size as u64)
+    );
+
+    Ok(())
+}

--- a/src/bin/copia/transfer.rs
+++ b/src/bin/copia/transfer.rs
@@ -97,11 +97,18 @@ pub async fn create_remote_dirs(
 
 /// Transfer a single file from local to remote via SSH streaming.
 /// Uses streaming I/O — does not read entire file into memory.
+/// Stream a local file to `host:remote_path` over SSH. Atomic + optionally
+/// mtime-preserving: the bytes land in a `.copia-tmp` sibling and are renamed
+/// into place (`mv -f`) only after a clean transfer, so an interrupted push
+/// never leaves a truncated/corrupt destination a reader could observe. When
+/// `mtime` is Some, the destination's mtime is set to it (epoch seconds) so the
+/// next run's quick check can skip the unchanged file.
 #[instrument(skip(local_path), fields(host, remote_path))]
 pub async fn transfer_file_to_remote(
     local_path: &Path,
     host: &str,
     remote_path: &str,
+    mtime: Option<i64>,
 ) -> Result<u64, String> {
     use tokio::io::AsyncReadExt;
 
@@ -110,11 +117,15 @@ pub async fn transfer_file_to_remote(
         .map_err(|e| format!("{}: {e}", local_path.display()))?;
     let file_size = metadata.len();
 
-    // Use $'...' quoting with backslash escapes for paths with special chars
+    // Use $'...' quoting with backslash escapes for paths with special chars.
     let escaped = remote_path.replace('\\', "\\\\").replace('\'', "\\'");
+    let tmp_escaped = format!("{escaped}.copia-tmp");
+    let touch = mtime.map_or(String::new(), |t| format!(" && touch -d @{t} $'{escaped}'"));
     let mut child = tokio::process::Command::new("ssh")
         .arg(host)
-        .arg(format!("cat > $'{escaped}'"))
+        .arg(format!(
+            "cat > $'{tmp_escaped}' && mv -f $'{tmp_escaped}' $'{escaped}'{touch}"
+        ))
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
@@ -155,25 +166,6 @@ pub async fn transfer_file_to_remote(
     }
 
     Ok(file_size)
-}
-
-/// Compute the total size of files relative to a root directory.
-pub fn compute_total_size(root: &Path, files: &[PathBuf]) -> u64 {
-    let mut total: u64 = 0;
-    let mut skipped = 0usize;
-    for f in files {
-        match std::fs::metadata(root.join(f)) {
-            Ok(m) => total += m.len(),
-            Err(_) => skipped += 1,
-        }
-    }
-    // GH-23: Warn if metadata errors caused files to be excluded from total
-    if skipped > 0 {
-        eprintln!(
-            "Warning: {skipped} file(s) excluded from size calculation (metadata unavailable)"
-        );
-    }
-    total
 }
 
 /// Calculate transfer speed in bytes per second.
@@ -262,18 +254,17 @@ mod transfer_tests {
     }
 
     #[test]
-    fn discover_and_total_size_over_a_temp_tree() {
+    fn discover_local_files_over_a_temp_tree() {
         let tmp = std::env::temp_dir().join(format!("copia-disc-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(tmp.join("sub")).unwrap();
-        std::fs::write(tmp.join("a.txt"), b"12345").unwrap(); // 5 bytes
-        std::fs::write(tmp.join("sub/b.txt"), b"678").unwrap(); // 3 bytes
+        std::fs::write(tmp.join("a.txt"), b"12345").unwrap();
+        std::fs::write(tmp.join("sub/b.txt"), b"678").unwrap();
         let files = discover_local_files(&tmp).unwrap();
         assert_eq!(
             files,
             vec![PathBuf::from("a.txt"), PathBuf::from("sub/b.txt")]
         );
-        assert_eq!(compute_total_size(&tmp, &files), 8);
         std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/tests/contract_falsification.rs
+++ b/tests/contract_falsification.rs
@@ -330,3 +330,163 @@ fn falsify_single_004_remote_to_remote_rejected() {
         "FALSIFY-SINGLE-004: expected an explicit rejection, got: {stderr}"
     );
 }
+
+// ── incremental-sync-v1 (L1-L4: tests here are L2; L3 Kani plan-kani-001; L4 Lean) ──
+
+fn seed(src: &std::path::Path) {
+    std::fs::create_dir_all(src.join("d")).unwrap();
+    std::fs::write(src.join("a.txt"), b"alpha").unwrap();
+    std::fs::write(src.join("d/b.bin"), vec![7u8; 4096]).unwrap();
+}
+fn out_of(cmd: &mut Command) -> (bool, String) {
+    let o = cmd.output().unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&o.stdout),
+        String::from_utf8_lossy(&o.stderr)
+    );
+    (o.status.success(), combined)
+}
+
+/// FALSIFY-INCR-001: a 2nd sync of an unchanged tree transfers 0 files.
+#[test]
+fn falsify_incr_001_idempotent_second_run_skips_all() {
+    let base = tmp("incr-idem");
+    let (src, dst) = (base.join("src"), base.join("dst"));
+    seed(&src);
+    let (s1, _) = out_of(copia().args(["sync", "-r"]).arg(&src).arg(&dst));
+    assert!(s1, "first sync must succeed");
+    let (s2, log) = out_of(copia().args(["sync", "-r"]).arg(&src).arg(&dst));
+    assert!(
+        s2 && (log.contains("0 to transfer") || log.contains("up to date")),
+        "FALSIFY-INCR-001: unchanged re-sync must skip all — got: {log}"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// FALSIFY-INCR-003: atomic delivery — content identical, no `.copia-tmp` survives.
+#[test]
+fn falsify_incr_003_atomic_no_tmp_survives() {
+    let base = tmp("incr-atomic");
+    let (src, dst) = (base.join("src"), base.join("dst"));
+    seed(&src);
+    assert!(out_of(copia().args(["sync", "-r"]).arg(&src).arg(&dst)).0);
+    assert_eq!(std::fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+    assert_eq!(std::fs::read(dst.join("d/b.bin")).unwrap(), vec![7u8; 4096]);
+    let leftover = walk_find(&dst, "copia-tmp");
+    assert!(
+        leftover.is_none(),
+        "FALSIFY-INCR-003: staging file survived: {leftover:?}"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// FALSIFY-INCR-004: `--exclude '*.tmp'` keeps matching files out of the destination.
+#[test]
+fn falsify_incr_004_exclude_omits_matches() {
+    let base = tmp("incr-excl");
+    let (src, dst) = (base.join("src"), base.join("dst"));
+    seed(&src);
+    std::fs::write(src.join("junk.tmp"), b"junk").unwrap();
+    assert!(
+        out_of(
+            copia()
+                .args(["sync", "-r", "--exclude", "*.tmp"])
+                .arg(&src)
+                .arg(&dst)
+        )
+        .0
+    );
+    assert!(dst.join("a.txt").exists(), "wanted file must sync");
+    assert!(
+        !dst.join("junk.tmp").exists(),
+        "FALSIFY-INCR-004: excluded file must NOT sync"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// FALSIFY-INCR-005: `--delete` mirrors away a stale dest file; without it, it stays.
+#[test]
+fn falsify_incr_005_delete_is_mirror_and_opt_in() {
+    let base = tmp("incr-del");
+    let (src, dst) = (base.join("src"), base.join("dst"));
+    seed(&src);
+    assert!(out_of(copia().args(["sync", "-r"]).arg(&src).arg(&dst)).0);
+    std::fs::remove_file(src.join("a.txt")).unwrap(); // a.txt now stale on dst
+                                                      // no --delete: stale file is retained
+    assert!(out_of(copia().args(["sync", "-r"]).arg(&src).arg(&dst)).0);
+    assert!(
+        dst.join("a.txt").exists(),
+        "without --delete, stale file must remain"
+    );
+    // --delete: stale file is mirrored away
+    assert!(out_of(copia().args(["sync", "-r", "--delete"]).arg(&src).arg(&dst)).0);
+    assert!(
+        !dst.join("a.txt").exists(),
+        "FALSIFY-INCR-005: --delete must remove the stale file"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// FALSIFY-INCR-006: `--dry-run` mutates nothing.
+#[test]
+fn falsify_incr_006_dry_run_mutates_nothing() {
+    let base = tmp("incr-dry");
+    let (src, dst) = (base.join("src"), base.join("dst"));
+    seed(&src);
+    let (ok, log) = out_of(copia().args(["sync", "-r", "-n"]).arg(&src).arg(&dst));
+    assert!(
+        ok && log.contains("dry run"),
+        "dry-run must report a plan: {log}"
+    );
+    assert!(
+        !dst.exists() || !dst.join("a.txt").exists(),
+        "FALSIFY-INCR-006: dry-run must not create destination files"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Recursively find a file whose name contains `needle` (for temp-file leak checks).
+fn walk_find(root: &std::path::Path, needle: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(root).ok()?;
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains(needle))
+        {
+            return Some(p);
+        }
+        if p.is_dir() {
+            if let Some(f) = walk_find(&p, needle) {
+                return Some(f);
+            }
+        }
+    }
+    None
+}
+
+/// FALSIFY-INCR-006b: `--dry-run --delete` lists the delete plan but removes nothing.
+#[test]
+fn falsify_incr_006b_dry_run_delete_lists_but_keeps() {
+    let base = tmp("incr-drydel");
+    let (src, dst) = (base.join("src"), base.join("dst"));
+    seed(&src);
+    assert!(out_of(copia().args(["sync", "-r"]).arg(&src).arg(&dst)).0);
+    std::fs::remove_file(src.join("a.txt")).unwrap();
+    let (ok, log) = out_of(
+        copia()
+            .args(["sync", "-r", "-n", "--delete"])
+            .arg(&src)
+            .arg(&dst),
+    );
+    assert!(
+        ok && log.contains("delete a.txt"),
+        "dry-run --delete must LIST the delete: {log}"
+    );
+    assert!(
+        dst.join("a.txt").exists(),
+        "FALSIFY-INCR-006b: dry-run must not actually delete"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/tests/e2e_ssh.rs
+++ b/tests/e2e_ssh.rs
@@ -403,3 +403,96 @@ fn e2e_signature_delta_patch_default_output_paths() {
 // CI note: these SSH e2e tests self-provision sshd + localhost keys in the
 // sovereign-ci container (openssh baked in) so the SSH-transport paths are
 // covered rather than skipped.
+
+#[test]
+fn e2e_incremental_push_idempotent_delete_verbose() {
+    if !ssh_localhost_ok() {
+        eprintln!("skip: no localhost ssh");
+        return;
+    }
+    let base = tmp("incr-push");
+    let src = base.join("src");
+    seed_tree(&src);
+    let rdst = base.join("rdst");
+    let remote = format!("localhost:{}/", rdst.display());
+    let src_arg = format!("{}/", src.display());
+    assert!(copia()
+        .args(["sync", "-r", &src_arg, &remote])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    // 2nd push, verbose → covers the run_remote skip path + verbose report
+    let out = copia()
+        .args(["sync", "-r", "-v", &src_arg, &remote])
+        .output()
+        .unwrap();
+    let log = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success() && (log.contains("up to date") || log.contains("0 to transfer")),
+        "push must be idempotent: {log}"
+    );
+    // push --delete removes a remote file no longer in source
+    std::fs::remove_file(src.join("a.txt")).unwrap();
+    assert!(copia()
+        .args(["sync", "-r", "--delete", &src_arg, &remote])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(
+        !rdst.join("a.txt").exists(),
+        "push --delete must remove the remote stale file"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+#[test]
+fn e2e_incremental_pull_delete() {
+    if !ssh_localhost_ok() {
+        eprintln!("skip: no localhost ssh");
+        return;
+    }
+    let base = tmp("incr-pull");
+    let rsrc = base.join("rsrc");
+    seed_tree(&rsrc);
+    let local = base.join("ldst");
+    let rsrc_arg = format!("localhost:{}/", rsrc.display());
+    let local_arg = format!("{}/", local.display());
+    assert!(copia()
+        .args(["sync", "-r", &rsrc_arg, &local_arg])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    std::fs::remove_file(rsrc.join("a.txt")).unwrap();
+    assert!(copia()
+        .args(["sync", "-r", "--delete", &rsrc_arg, &local_arg])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(
+        !local.join("a.txt").exists(),
+        "pull --delete must remove the local stale file"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+#[test]
+fn e2e_recursive_remote_to_remote_rejected() {
+    // Reaches the reject branch before any SSH — safe offline.
+    let out = copia()
+        .args(["sync", "-r", "h1:/a", "h2:/b"])
+        .env("PATH", "/nonexistent-copia-path")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "recursive remote->remote must be rejected"
+    );
+}


### PR DESCRIPTION
## Competitive analysis → the #1 gap, closed

A 5-way competitive analysis (rsync, rclone, restic, librsync/casync, Unison/Syncthing) unanimously flagged the same **CRITICAL** gap: copia's `sync` re-shipped **whole files every run** — no skip-unchanged, no delta, no metadata. rsync's entire reason to exist, missing. For the rag-sync use case that meant moving **1.4 GiB every 6h even when nothing changed**.

`copia sync -r` is now a real **incremental mirror** across all three directions (push / pull / local), unified through one planner:

- **Quick-check skip** — transfer only files whose size OR mtime differ. Proven over SSH: a 2nd sync of the 1.4G RAG index transfers **0 files**.
- **Atomic delivery** — bytes land in a `.copia-tmp` sibling and `rename(2)` into place only after a clean transfer. An interrupted run never leaves a torn destination file (real corruption fix).
- **mtime preservation** (`touch -d @` / `File::set_modified`) so the next quick-check is idempotent.
- **`--exclude GLOB`** (gitignore-style), **`--delete`** (opt-in mirror), **`--dry-run`**.

## Architecture — L1 of the distributed roadmap

This is **L1** (incremental one-way) of the agreed multi-node → bidirectional → hub-daemon roadmap. `plan.rs` (pure planner: `needs_transfer`/`build_plan`/glob), `meta.rs` (both-sides metadata), `incremental.rs` (orchestration + atomic delivery). Both L2 (bidirectional conflict-copy) and L3 (`copia --server` hub) reuse the same `MetaMap` diff + atomic primitive.

## Provable contract spans L1–L4

`contracts/incremental-sync-v1.yaml`:
- **L2** — 6 `FALSIFY-INCR` falsification #[test]s (idempotence / atomic / exclude / delete / dry-run).
- **L3** — Kani harness `plan-kani-001` **VERIFIED** (`cargo kani`, exhaustive over all size/mtime pairs).
- **L4** — 3 Lean 4 theorems **PROVED** (`lean/IncrementalSync.lean`, no `sorry`): QuickCheckCorrect, SkipGuarantee, DeleteOptIn.

Whole-crate coverage **95.81%**; 318 tests; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)