### PR TITLE
fix(ci): release.yml gate referenced nonexistent paiml/infra/unified-gate.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
   # ── Gate: unified CI must pass before publish ──────────
   gate:
     needs: create-release
-    uses: paiml/infra/.github/workflows/unified-gate.yml@main
+    uses: paiml/.github/.github/workflows/unified-gate.yml@main
     with:
       repo: ${{ github.event.repository.name }}
       pr_sha: ${{ github.sha }}


### PR DESCRIPTION
## The bug
copia's tag-triggered `release.yml` failed in **0 seconds** with GitHub's "this run likely failed because of a workflow file issue" (no jobs) on **every run** — which is why 0.1.4, 0.1.5, and 0.2.0 were all published via the manual OOB fallback instead of the automated workflow.

## Root cause
The `gate` job used:
```yaml
uses: paiml/infra/.github/workflows/unified-gate.yml@main   # ← does not exist
```
infra **deleted** its copy of `unified-gate.yml` (PMAT-059). A `uses:` pointing at a reusable workflow that doesn't exist makes GitHub reject the entire workflow file at load time — hence 0 jobs, 0 seconds, "file issue."

The canonical reusable workflow lives in the org `.github` repo:
```yaml
uses: paiml/.github/.github/workflows/unified-gate.yml@main   # ✓ exists; workflow_call inputs repo+pr_sha match
```
The clean-room release **template already had the correct reference** — copia's deployed copy was stale by exactly this one line (confirmed by diffing `machines/clean-room/templates/release.yml` against the deployed file: identical except line 108).

## Result
`v*` tag pushes once again drive the full automated release: draft → unified-gate → verify → OIDC crates.io publish → cross-compiled binaries → finalize. Validated post-merge with a throwaway tag (workflow now parses and starts jobs instead of failing at load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)