### PR TITLE
fix(deps): crossbeam-epoch 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## RUSTSEC-2026-0204

`crossbeam-epoch` 0.9.18 → **0.9.20**. Invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid.

Patch-level bump inside the existing semver range, so **only `Cargo.lock` changes**.

## How it was found

Running the fleet lane-liveness dead-man's switch (PMAT-185). `whisper.apr`, `pepita` and `pzsh` *Nightly Bench* had each been failing for exactly **23 days** — matching this advisory's publication date — all on this one crate. A scan then found **90 of 94** local repos carrying the vulnerable `0.9.18`.

Ten repos in the liveness fleet scope were affected; this is one of them. Tracked as **PMAT-203**.

## Verification

`cargo audit` no longer reports RUSTSEC-2026-0204 for this repo. Any other advisories present are pre-existing and deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
