### PR TITLE
fix(checksum): widen RollingChecksum accumulators to u64 (large block sizes never matched)

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -74,20 +74,23 @@ impl RollingChecksum {
     #[cfg_attr(feature = "contracts", ensures(ret.b < Self::MOD, "b < MOD"))]
     #[cfg_attr(feature = "contracts", ensures(ret.count == data.len(), "count == input len"))]
     pub fn new(data: &[u8]) -> Self {
-        let mut a: u32 = 0;
-        let mut b: u32 = 0;
+        // Accumulate in u64: the weighted sum b = Σ (len-i)·byte reaches
+        // ~255·len²/2, which overflows u32 for windows ≥ ~8-16 KiB and would
+        // silently disagree with FastRollingChecksum (u64) used by the delta
+        // matcher — breaking block matching for large block sizes.
+        let mut a: u64 = 0;
+        let mut b: u64 = 0;
         let len = data.len();
 
         for (i, &byte) in data.iter().enumerate() {
-            a = a.wrapping_add(u32::from(byte));
+            a = a.wrapping_add(u64::from(byte));
             // Weight is (len - i) so first byte has highest weight
-            // Truncation is intentional: checksum uses 32-bit arithmetic
-            b = b.wrapping_add((len - i) as u32 * u32::from(byte));
+            b = b.wrapping_add((len - i) as u64 * u64::from(byte));
         }
 
         let result = Self {
-            a: a % Self::MOD,
-            b: b % Self::MOD,
+            a: (a % u64::from(Self::MOD)) as u32,
+            b: (b % u64::from(Self::MOD)) as u32,
             count: len,
         };
         debug_assert!(result.a < Self::MOD, "a must be < MOD after init");
@@ -352,6 +355,22 @@ mod tests {
     // ==========================================================================
     // UNIT TESTS - Basic functionality
     // ==========================================================================
+
+    #[test]
+    fn strict_and_fast_rolling_checksums_agree_for_all_block_sizes() {
+        // RollingChecksum (u32 accumulators historically) feeds signature weak
+        // hashes; FastRollingChecksum (u64) feeds the delta matcher. For
+        // windows where Σ (len-i)·byte exceeds u32::MAX the strict variant
+        // used to wrap and disagree, so no block ever matched. See issue #44.
+        for &bs in &[512usize, 1024, 2048, 4096, 8192, 16384, 32768, 65536] {
+            let data: Vec<u8> = (0..bs).map(|i| (i * 31 % 251) as u8).collect();
+            assert_eq!(
+                RollingChecksum::new(&data).digest(),
+                FastRollingChecksum::new(&data).digest(),
+                "strict/fast weak-hash disagreement at block_size {bs}"
+            );
+        }
+    }
 
     #[test]
     fn new_empty_slice() {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -428,6 +428,27 @@ mod tests {
     // ==========================================================================
 
     #[test]
+    fn identity_delta_uses_copy_ops_at_large_block_size() {
+        // Regression for issue #44: with block_size ≥ 16 KiB the signature's
+        // weak hashes disagreed with the delta matcher's rolling checksum,
+        // so even identical inputs produced an all-literal delta.
+        let data: Vec<u8> = (0..1usize << 20)
+            .map(|i| (i * 31 % 251) as u8)
+            .collect();
+        let sync = SyncBuilder::new()
+            .block_size(65_536)
+            .strong_hash_len(32)
+            .build();
+        let sig = sync.signature(Cursor::new(&data)).unwrap();
+        let delta = sync.delta(Cursor::new(&data), &sig).unwrap();
+        assert_eq!(delta.bytes_literal(), 0, "identity input must not be literal");
+        assert!(
+            delta.bytes_matched() == data.len() as u64,
+            "identity input must be fully matched by copy ops"
+        );
+    }
+
+    #[test]
     fn builder_default() {
         let sync = SyncBuilder::new().build();
         assert_eq!(sync.block_size(), 2048);


### PR DESCRIPTION
## Summary

Widens the accumulators in `RollingChecksum::new` from `u32` to `u64`. Full root-cause analysis, public-API repro, and measurements in #44.

`b = Σ (len−i)·byte` reaches ≈ `255·len²/2`, which overflows `u32` for `block_size ≥ 16384` (data-dependent at 8192). The wrapped digest then disagrees with `FastRollingChecksum` (u64) used by `CopiaSync::delta`, so **no block ever matches for large block sizes**: every delta over a large file degrades to 100% literal after a byte-by-byte slide. Values are unchanged for windows below the overflow threshold, so small-block behavior is identical.

## Measured impact (identity input, block_size 65536, release)

| size | before | after | literal bytes |
|---|---|---|---|
| 64 MiB | 1467 ms, 0 matches | 130 ms, all matched | 100% → **0** |
| 1 GiB | ≈ 23.5 s, 0 matches | 3.2 s, all matched | 100% → **0** |

## Tests

Adds two regression tests:

- `strict_and_fast_rolling_checksums_agree_for_all_block_sizes` — the exact disagreement that let this ship (both variants must agree for every legal block size 512–65536)
- `identity_delta_uses_copy_ops_at_large_block_size` — identity input at block_size 65536 must produce copy ops, not literals

Full A/B against `main` (`--no-fail-fast`, same toolchain): unit tests 227 → **229 passed** (+2 new); every other test binary — including the 30 pre-existing failures in the `contract_falsification` / integration targets — is byte-for-byte identical before and after this change. `cargo clippy` on the lib is clean.

Fixes #44
