### PR TITLE
feat(verify): verify-before-delete, and the three data-loss bugs the rsync harness found (Closes #46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,17 @@ jobs:
       - name: Validate provable contracts (schema)
         run: |
           if command -v pv >/dev/null 2>&1; then
-            for c in contracts/*.yaml; do pv validate "$c"; done
+            # `contracts/binding.yaml` is a BINDINGS MANIFEST, not a contract:
+            # it maps each contract equation to the function implementing it and
+            # is consumed by `pv proof-status --binding`. Its schema has no
+            # `metadata` block and `pv validate` rightly rejects it. The loop was
+            # written before that file existed and this step only runs when `pv`
+            # is on the runner, so the mismatch stayed invisible until a runner
+            # had it — the last green ci.yml on main predates the file entirely.
+            for c in contracts/*.yaml; do
+              [ "$(basename "$c")" = "binding.yaml" ] && continue
+              pv validate "$c"
+            done
           else
             echo "pv unavailable on this runner — schema validation is covered by the nightly + local \`make contracts\`; falsification #[test]s still gate in ci/test"
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/contracts/binding.yaml
+++ b/contracts/binding.yaml
@@ -100,3 +100,35 @@ bindings:
     function: handle_put
     signature: 'fn handle_put<R, W>(...) -> std::io::Result<()>'
     status: implemented
+
+  # ── verify-before-delete-v1 ──
+  - contract: verify-before-delete-v1.yaml
+    equation: content_oracle
+    module_path: copia::verify
+    function: compare
+    signature: 'fn compare(src: &Path, dest: &Path) -> Result<Report, Box<dyn std::error::Error>>'
+    status: implemented
+  - contract: verify-before-delete-v1.yaml
+    equation: positive_evidence_delete
+    module_path: copia::verify
+    function: safe_to_delete_for
+    signature: 'const fn safe_to_delete_for(identical: usize, differs: usize, missing: usize, extra: usize, unreadable: usize) -> bool'
+    status: implemented
+  - contract: verify-before-delete-v1.yaml
+    equation: unreadable_is_not_a_verdict
+    module_path: copia::verify
+    function: exit_code_for
+    signature: 'const fn exit_code_for(differs: usize, missing: usize, extra: usize, unreadable: usize) -> i32'
+    status: implemented
+  - contract: verify-before-delete-v1.yaml
+    equation: read_only
+    module_path: copia::verify
+    function: scan
+    signature: 'fn scan(root: &Path) -> Result<Scan, Box<dyn std::error::Error>>'
+    status: implemented
+  - contract: verify-before-delete-v1.yaml
+    equation: rsync_equivalence
+    module_path: copia::transfer
+    function: discover_local_dirs
+    signature: 'fn discover_local_dirs(root: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>>'
+    status: implemented

--- a/contracts/verify-before-delete-v1.yaml
+++ b/contracts/verify-before-delete-v1.yaml
@@ -1,0 +1,179 @@
+metadata:
+  id: C-COPIA-VERIFY-BEFORE-DELETE
+  version: "1.0.0"
+  created: "2026-08-22"
+  author: "PAIML Engineering"
+  kind: pattern
+  status: ACTIVE
+  description: |
+    Pins `copia verify` — the pass that authorises destroying data. copia is the
+    Sovereign AI Stack's rsync replacement; until this it was that for TRANSFER and
+    not for ARCHIVAL, so the one operation where being wrong destroys data (move a
+    tree, then delete the original) was still delegated to rsync. forjar's
+    nas_archive moves 755 GB to the NAS and deletes the source.
+
+    The contract is narrow and absolute: a deletion is authorised ONLY by positive
+    evidence — every path compared by CONTENT, nothing unreadable, nothing missing,
+    nothing extra, and at least one path actually examined. "I could not look" is
+    never reported as "I looked and found nothing wrong", and never as "I looked and
+    found a difference" either; it is its own outcome with its own exit code.
+  references:
+    - "verify::compare — the read-only content comparison over both trees"
+    - "verify::exit_code_for / safe_to_delete_for — the pure decision, Kani-proved"
+    - "verify::scan — records unreadable paths instead of dropping them"
+    - "meta::fingerprint_path — streaming blake3; a symlink hashes its target string"
+    - "transfer::discover_local_files — the shared walk; symlinks are entries, not doors"
+    - "tests/rsync_differential.rs — rsync as the oracle for the behaviour being replaced"
+
+equations:
+  content_oracle:
+    formula: "identical(p) <=> blake3(a[p]) == blake3(b[p]) AND ftype(a[p]) == ftype(b[p])"
+    domain: "p in relpaths(src) union relpaths(dest)"
+    invariants:
+      - "size and mtime never appear in a verify decision"
+      - "a file<->symlink type flip is a difference even if the hashed bytes coincide"
+      - "a symlink is compared by its TARGET STRING, never by following it"
+  positive_evidence_delete:
+    formula: "safe_to_delete <=> identical > 0 AND differs = missing = extra = unreadable = 0"
+    domain: "the five counts of one comparison"
+    invariants:
+      - "identical > 0 is required: two empty trees examine nothing and must not authorise a delete"
+      - "no single non-zero failure count can be overridden by a large identical count"
+  unreadable_is_not_a_verdict:
+    formula: "unreadable > 0 => exit = 2, and exit 2 != exit 1"
+    domain: "any comparison where a path could not be read on either side"
+    invariants:
+      - "an unreadable path is never counted identical"
+      - "an unreadable path is never reported as a difference"
+      - "the scan RECORDS read failures; it never drops them the way discover_local_fingerprints does"
+  read_only:
+    formula: "fingerprints(src, dest) before verify == fingerprints(src, dest) after verify"
+    domain: "any pair of trees"
+    invariants:
+      - "verify holds no write handle to either tree"
+      - "a symlink is never followed for writing, and its target is never stamped"
+  rsync_equivalence:
+    formula: "copia_verify_identical(a,b) <=> rsync -a --checksum --dry-run --itemize-changes produces no output"
+    domain: "the fixture shapes in tests/rsync_differential.rs"
+    invariants:
+      - "agreement is required in BOTH directions; a verifier that always says identical satisfies only one"
+      - "copia sync -r must produce the same tree as rsync -a: structure, content, symlink-ness and link targets"
+
+proof_obligations:
+  - type: safety
+    property: "No delete without positive evidence"
+    formal: "safe_to_delete_for(i,d,m,e,u) => i>0 AND d=0 AND m=0 AND e=0 AND u=0"
+    applies_to: positive_evidence_delete
+    kani:
+      harness: verify_never_authorises_a_delete_without_positive_evidence
+      status: proved
+  - type: safety
+    property: "Unreadable outranks differs and is total"
+    formal: "u>0 => exit=2; and exit in {0,1,2} always"
+    applies_to: unreadable_is_not_a_verdict
+    kani:
+      harness: unreadable_is_never_reported_as_a_difference
+      status: proved
+  - type: safety
+    property: "Verify mutates neither tree"
+    formal: "fingerprints before == fingerprints after"
+    applies_to: read_only
+    test: "verify::tests::verify_read_only_never_writes"
+  - type: soundness
+    property: "Content, not size+mtime"
+    formal: "equal size AND equal mtime AND differing bytes => differs"
+    applies_to: content_oracle
+    test: "verify::tests::same_size_same_mtime_different_bytes_is_caught"
+  - type: equivalence
+    property: "copia agrees with the tool it replaces"
+    formal: "for every fixture shape, copia_sync == rsync -a AND copia_verify == rsync --checksum"
+    applies_to: rsync_equivalence
+    test: "tests/rsync_differential.rs"
+
+verification_summary:
+  total_obligations: 5
+  l2_property_tested: 5
+  l3_kani_proved: 2
+  l4_lean_proved: 0
+  l4_sorry_count: 0
+  l4_not_applicable: 3
+  notes: |
+    The two Kani harnesses target `exit_code_for` / `safe_to_delete_for`, never
+    `Report`. That is the allocation-free boundary: `Report` carries Vecs, and a
+    harness constructing one drags the allocator and core::fmt into the model —
+    measured elsewhere in this fleet at 117 minutes for a 216-case space. Over
+    four bounded counts the same property is exhaustive and instant.
+
+    The three obligations without a Kani harness are properties of the
+    FILESYSTEM, not of a decision function: whether a run wrote anything, whether
+    blake3 distinguishes equal-size files, and whether copia matches rsync. A
+    bounded model cannot say anything useful about any of them, so they are
+    proved by EXECUTION and the contract says so rather than claiming a proof
+    that does not exist.
+
+falsification_tests:
+  - id: FALSIFY-VERIFY-001
+    rule: "No delete without positive evidence"
+    prediction: "Weakening safe_to_delete_for to ignore `unreadable` makes the Kani harness FAIL"
+    test: "kani verify_never_authorises_a_delete_without_positive_evidence"
+    if_fails: "copia authorises deleting 755 GB over paths it could not read"
+    verified: "2026-08-22 — injected the weakening; VERIFICATION:- FAILED with `authorised a delete over unreadable paths`"
+  - id: FALSIFY-VERIFY-002
+    rule: "Content, not size+mtime"
+    prediction: "One byte changed at equal size with mtime forced equal is reported as differs, exit 1"
+    test: "verify::tests::same_size_same_mtime_different_bytes_is_caught"
+    if_fails: "a truncated or corrupted file passes verification and its source is deleted"
+  - id: FALSIFY-VERIFY-003
+    rule: "Verify mutates neither tree"
+    prediction: "Fingerprints of both trees are unchanged across a full run"
+    test: "verify::tests::verify_read_only_never_writes"
+    if_fails: "the verifier alters the evidence it is judging"
+  - id: FALSIFY-VERIFY-004
+    rule: "An empty comparison proves nothing"
+    prediction: "Two empty trees are NOT safe_to_delete_source despite zero failures"
+    test: "verify::tests::two_empty_trees_are_not_safe_to_delete"
+    if_fails: "a comparison that examined nothing authorises a deletion"
+  - id: FALSIFY-VERIFY-005
+    rule: "copia agrees with rsync"
+    prediction: "Removing the symlink handling makes copia_sync_matches_rsync_on_every_shape FAIL"
+    test: "tests/rsync_differential.rs::copia_sync_matches_rsync_on_every_shape"
+    if_fails: "copia silently loses symlinks, empty directories or dangling links, and verify — sharing the same walk — reports the trees IDENTICAL over the loss"
+    verified: "2026-08-22 — the harness caught exactly this on first run: symlink-to-dir dropped, dangling symlink dropped, empty dir dropped"
+  - id: FALSIFY-VERIFY-006
+    rule: "The oracle must exist"
+    prediction: "With rsync absent, the differential suite FAILS rather than passing vacuously"
+    test: "tests/rsync_differential.rs::the_oracle_is_present"
+    if_fails: "every differential case compares copia against nothing and reports PASS"
+
+kani_harnesses:
+  - id: verify-kani-001
+    obligation: "No delete without positive evidence"
+    harness: verify::verify_never_authorises_a_delete_without_positive_evidence
+    bound: 3
+    strategy: bounded_int
+    status: PROVED
+    notes: "cargo kani --features cli — SUCCESSFUL. Bound 3 covers every distinct case; the property depends on zero vs non-zero, not magnitude."
+  - id: verify-kani-002
+    obligation: "Unreadable outranks differs and the code set is total"
+    harness: verify::unreadable_is_never_reported_as_a_difference
+    bound: 3
+    strategy: bounded_int
+    status: PROVED
+    notes: "cargo kani --features cli — SUCCESSFUL."
+
+qa_gate:
+  id: F-VERIFY-001
+  name: Verify-Before-Delete Contract
+  description: |
+    copia verify authorises a deletion only on positive, content-based evidence,
+    never mutates what it inspects, and agrees with the tool it replaces.
+  checks:
+    - content_oracle
+    - positive_evidence_delete
+    - unreadable_is_not_a_verdict
+    - read_only
+    - rsync_equivalence
+  pass_criteria: |
+    All 6 FALSIFY-VERIFY tests pass (L2); both verify Kani harnesses report
+    VERIFICATION:- SUCCESSFUL (L3); the rsync differential harness passes on every
+    fixture shape with rsync PRESENT — an absent oracle is a FAIL, not a skip.

--- a/src/bin/copia/incremental.rs
+++ b/src/bin/copia/incremental.rs
@@ -384,6 +384,67 @@ async fn deliver_local(src: &Path, dst: &Path, mtime: Option<i64>) -> Result<u64
 mod tests {
     use super::*;
 
+    /// `deliver_local` must recreate a symlink, not copy what it points at.
+    ///
+    /// `tokio::fs::copy` dereferences, so the previous version replaced
+    /// `link -> target` with a second copy of the target's bytes: the link was
+    /// gone and the tree silently grew. Caught by the rsync differential
+    /// harness; pinned here so it cannot regress without a unit failure.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deliver_local_recreates_a_symlink_rather_than_following_it() {
+        let base = std::env::temp_dir().join(format!("copia-dl-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let target = base.join("target.txt");
+        std::fs::write(&target, b"payload").unwrap();
+        let link = base.join("link");
+        std::os::unix::fs::symlink("target.txt", &link).unwrap();
+        let dst = base.join("delivered");
+
+        deliver_local(&link, &dst, Some(1_000_000)).await.unwrap();
+
+        let md = std::fs::symlink_metadata(&dst).unwrap();
+        assert!(
+            md.file_type().is_symlink(),
+            "delivered a regular file where the source was a symlink"
+        );
+        assert_eq!(
+            std::fs::read_link(&dst).unwrap(),
+            std::path::PathBuf::from("target.txt")
+        );
+
+        // The TARGET must be untouched. `utimes` follows a link, so stamping the
+        // delivered path would have mutated a file we were only asked to link to.
+        let tmeta = std::fs::metadata(&target).unwrap();
+        assert_eq!(tmeta.len(), 7, "the link's target was rewritten");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Delivering over an existing regular file must leave a link, not fail.
+    /// That is exactly the state the old dereferencing behaviour left behind,
+    /// so the first corrected run has to be able to repair it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deliver_local_replaces_a_stale_regular_file_with_the_link() {
+        let base = std::env::temp_dir().join(format!("copia-dl2-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("t.txt"), b"x").unwrap();
+        let link = base.join("l");
+        std::os::unix::fs::symlink("t.txt", &link).unwrap();
+        let dst = base.join("stale");
+        std::fs::write(&dst, b"left over from the dereferencing bug").unwrap();
+
+        deliver_local(&link, &dst, None).await.unwrap();
+
+        assert!(std::fs::symlink_metadata(&dst)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
     #[test]
     fn tmp_path_appends_suffix_without_colliding() {
         assert_eq!(

--- a/src/bin/copia/incremental.rs
+++ b/src/bin/copia/incremental.rs
@@ -289,7 +289,16 @@ async fn run_local(
         return Ok(());
     }
 
-    create_local_dirs(dst, &collect_dirs(&plan.transfer))?;
+    // Create EVERY directory in the source, not only the ones that happen to
+    // contain a file in this transfer. An empty directory is structure, and an
+    // archive that drops it has not faithfully copied the tree even though
+    // every byte arrived (infra rsync-differential, `empty-dir` shape).
+    // Falls back to the file-derived set if the source cannot be walked, so a
+    // discovery failure degrades to the previous behaviour rather than
+    // aborting a transfer that would otherwise succeed.
+    let all_dirs =
+        crate::transfer::discover_local_dirs(src).unwrap_or_else(|_| collect_dirs(&plan.transfer));
+    create_local_dirs(dst, &all_dirs)?;
     let semaphore = Arc::new(Semaphore::new(opts.jobs));
     let progress = TransferProgress::new(plan.transfer.len() as u64);
     let mut handles = Vec::with_capacity(plan.transfer.len());
@@ -326,8 +335,37 @@ async fn run_local(
     )
 }
 
-/// Atomic local copy: copy to a `.copia-tmp` sibling, rename, set mtime.
+/// Atomic local delivery: write a `.copia-tmp` sibling, rename, set mtime.
+///
+/// A SYMLINK is recreated as a symlink, never followed. `tokio::fs::copy`
+/// dereferences, so the previous version replaced `link -> target` with a second
+/// copy of the target's bytes — the link was gone and the tree silently grew.
+/// Paired with the walk fix in `transfer::discover_local_files`; either alone
+/// leaves `copia verify` disagreeing with what `copia sync` actually wrote.
 async fn deliver_local(src: &Path, dst: &Path, mtime: Option<i64>) -> Result<u64, String> {
+    if let Ok(md) = tokio::fs::symlink_metadata(src).await {
+        if md.file_type().is_symlink() {
+            let target = tokio::fs::read_link(src)
+                .await
+                .map_err(|e| format!("read_link {}: {e}", src.display()))?;
+            // Replace whatever is there. A stale regular file at this path is
+            // exactly what the old dereferencing behaviour left behind.
+            let _ = tokio::fs::remove_file(dst).await;
+            #[cfg(unix)]
+            tokio::fs::symlink(&target, dst)
+                .await
+                .map_err(|e| format!("symlink {}: {e}", dst.display()))?;
+            #[cfg(not(unix))]
+            return Err(format!(
+                "cannot recreate symlink {} on this platform",
+                dst.display()
+            ));
+            // mtime is deliberately NOT set: on Linux `utimes` follows the link
+            // and would stamp the TARGET, mutating a file we were only asked to
+            // link to. rsync needs -h/--no-dereference for the same reason.
+            return Ok(0);
+        }
+    }
     let tmp = tmp_path(dst);
     let size = tokio::fs::copy(src, &tmp)
         .await

--- a/src/bin/copia/main.rs
+++ b/src/bin/copia/main.rs
@@ -57,6 +57,25 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Prove two local trees are byte-identical, changing nothing
+    ///
+    /// Exit codes are a contract, because a caller deletes 755 GB on them:
+    ///   0 identical (safe to delete the source) · 1 differences found
+    ///   2 could not compare — NOT the same as 1 · 3 error before comparing
+    Verify {
+        /// Source tree
+        #[arg(required = true)]
+        source: PathBuf,
+
+        /// Destination tree, the one about to justify a deletion
+        #[arg(required = true)]
+        dest: PathBuf,
+
+        /// Suppress the per-path lines; the summary and exit code remain
+        #[arg(short, long)]
+        quiet: bool,
+    },
+
     /// Synchronize source to destination (supports host:path for SSH)
     Sync {
         /// Source path (local path or host:path for SSH)
@@ -228,6 +247,17 @@ async fn main() -> ExitCode {
 #[instrument(skip(cli))]
 async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
+        Commands::Verify {
+            source,
+            dest,
+            quiet,
+        } => {
+            // The exit code IS the result. Returning it through the normal Ok
+            // path would collapse 1 and 2 into "success", which is the
+            // distinction the whole command exists to preserve.
+            std::process::exit(verify::verify(&source, &dest, quiet));
+        }
+
         Commands::Sync {
             source,
             dest,
@@ -291,6 +321,7 @@ mod reconcile;
 mod serve;
 mod single_sync;
 mod transfer;
+mod verify;
 mod wire;
 use incremental::{run_sync_recursive, SyncOptions};
 use single_sync::run_sync;

--- a/src/bin/copia/meta.rs
+++ b/src/bin/copia/meta.rs
@@ -53,7 +53,13 @@ fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
 pub fn discover_local_with_meta(root: &Path) -> Result<MetaMap, Box<dyn std::error::Error>> {
     let mut out = MetaMap::new();
     for rel in discover_local_files(root)? {
-        if let Ok(meta) = std::fs::metadata(root.join(&rel)) {
+        // symlink_metadata, not metadata: `metadata` FOLLOWS the link, so a
+        // DANGLING symlink errors and the `if let Ok` silently drops it from
+        // the plan — copia then omits a path rsync -a faithfully recreates.
+        // Caught by the rsync differential harness on the `dangling-symlink`
+        // shape. A symlink's own size/mtime is the right quick-check value
+        // anyway; `deliver_local` recreates it as a link regardless.
+        if let Ok(meta) = std::fs::symlink_metadata(root.join(&rel)) {
             out.insert(
                 rel,
                 FileMeta {

--- a/src/bin/copia/transfer.rs
+++ b/src/bin/copia/transfer.rs
@@ -14,7 +14,24 @@ pub fn discover_local_files(root: &Path) -> Result<Vec<PathBuf>, Box<dyn std::er
         for entry in entries {
             let entry = entry?;
             let path = entry.path();
-            if path.is_dir() && !path.is_symlink() {
+            // ORDER MATTERS: a symlink is an ENTRY, never a door to walk
+            // through, so it is classified before is_dir/is_file — both of
+            // which FOLLOW links.
+            //
+            // The previous order lost data twice over. `is_file()` follows, so
+            // a symlink-to-file was copied as its target's bytes and the link
+            // was gone. Worse, a symlink-to-DIRECTORY matched `is_dir()` but
+            // was excluded by `!is_symlink()`, and then failed `is_file()` —
+            // so it was dropped from the walk entirely. Measured 2026-08-22:
+            // `copia sync -r` silently discarded `dirlink -> realdir`, and
+            // because `copia verify` shares this walk the path was absent from
+            // BOTH scans and the trees compared IDENTICAL. A verifier that
+            // authorises deleting a source reported success over data it had
+            // just lost.
+            if path.is_symlink() {
+                let rel = path.strip_prefix(root)?.to_path_buf();
+                files.push(rel);
+            } else if path.is_dir() {
                 dirs.push(path);
             } else if path.is_file() {
                 let rel = path.strip_prefix(root)?.to_path_buf();
@@ -25,6 +42,37 @@ pub fn discover_local_files(root: &Path) -> Result<Vec<PathBuf>, Box<dyn std::er
 
     files.sort();
     Ok(files)
+}
+
+/// Every directory under `root`, relative — INCLUDING ones that hold no files.
+///
+/// `collect_dirs` derives directories from file paths, so a directory with no
+/// files in it does not exist as far as the sync is concerned and is never
+/// created at the destination. rsync -a preserves it. Caught by the rsync
+/// differential harness on the `empty-dir` shape.
+///
+/// Structure is part of what an ARCHIVE is: a course tree whose empty chapter
+/// directories vanish on the way to the NAS has not been faithfully archived,
+/// even though every byte arrived.
+pub fn discover_local_dirs(root: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)? {
+            let path = entry?.path();
+            // Never walk THROUGH a symlink: it is an entry, and following one
+            // can also loop forever.
+            if path.is_symlink() {
+                continue;
+            }
+            if path.is_dir() {
+                out.push(path.strip_prefix(root)?.to_path_buf());
+                stack.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
 }
 
 /// Collect unique directory paths from a list of relative file paths.

--- a/src/bin/copia/transfer.rs
+++ b/src/bin/copia/transfer.rs
@@ -286,6 +286,76 @@ mod transfer_tests {
     }
 
     #[test]
+    fn discover_local_dirs_finds_directories_with_no_files() {
+        let tmp = std::env::temp_dir().join(format!("copia-dld-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("a/b/c")).unwrap();
+        std::fs::create_dir_all(tmp.join("hollow")).unwrap();
+        std::fs::write(tmp.join("a/f.txt"), b"x").unwrap();
+
+        let dirs = discover_local_dirs(&tmp).unwrap();
+        // `hollow` holds no files, so collect_dirs cannot see it at all — that
+        // is the empty-directory loss this function exists to prevent.
+        assert!(
+            dirs.contains(&PathBuf::from("hollow")),
+            "an empty directory was not discovered: {dirs:?}"
+        );
+        assert!(dirs.contains(&PathBuf::from("a/b/c")), "{dirs:?}");
+        assert!(
+            !collect_dirs(&[PathBuf::from("a/f.txt")]).contains(&PathBuf::from("hollow")),
+            "fixture is wrong: collect_dirs must NOT find the empty dir, or this \
+             test is not measuring the difference"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn discover_local_dirs_does_not_walk_through_a_symlink() {
+        let tmp = std::env::temp_dir().join(format!("copia-dld2-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("real/inner")).unwrap();
+        std::os::unix::fs::symlink("real", tmp.join("link")).unwrap();
+
+        let dirs = discover_local_dirs(&tmp).unwrap();
+        assert!(dirs.contains(&PathBuf::from("real")), "{dirs:?}");
+        assert!(
+            !dirs.iter().any(|d| d.starts_with("link")),
+            "walked THROUGH a symlink — that duplicates the tree and can loop \
+             forever on a cycle: {dirs:?}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn the_walk_surfaces_symlinks_instead_of_following_or_dropping_them() {
+        let tmp = std::env::temp_dir().join(format!("copia-walk-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("realdir")).unwrap();
+        std::fs::write(tmp.join("realdir/inside.txt"), b"x").unwrap();
+        std::os::unix::fs::symlink("realdir", tmp.join("dirlink")).unwrap();
+        std::os::unix::fs::symlink("nowhere", tmp.join("dangling")).unwrap();
+
+        let files = discover_local_files(&tmp).unwrap();
+        // Both were invisible before: a symlinked DIRECTORY matched is_dir() but
+        // was excluded by !is_symlink() and then failed is_file(), so it left the
+        // walk entirely — and `copia verify` shares this walk, so the trees
+        // compared IDENTICAL over the loss.
+        assert!(files.contains(&PathBuf::from("dirlink")), "{files:?}");
+        assert!(files.contains(&PathBuf::from("dangling")), "{files:?}");
+        assert!(
+            files.contains(&PathBuf::from("realdir/inside.txt")),
+            "{files:?}"
+        );
+        assert!(
+            !files.contains(&PathBuf::from("dirlink/inside.txt")),
+            "followed the symlink and duplicated its contents: {files:?}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn collect_dirs_builds_unique_sorted_parent_set() {
         let files = vec![
             PathBuf::from("a.txt"),

--- a/src/bin/copia/verify.rs
+++ b/src/bin/copia/verify.rs
@@ -107,19 +107,59 @@ impl Report {
     /// other — and collapsing them would let "I could not look" be reported as
     /// "I looked and found a difference", which is a claim we did not earn.
     pub fn exit_code(&self) -> i32 {
-        if !self.unreadable.is_empty() {
-            EXIT_UNREADABLE
-        } else if !self.differs.is_empty() || !self.missing.is_empty() || !self.extra.is_empty() {
-            EXIT_DIFFERS
-        } else {
-            EXIT_IDENTICAL
-        }
+        exit_code_for(
+            self.differs.len(),
+            self.missing.len(),
+            self.extra.len(),
+            self.unreadable.len(),
+        )
     }
 
     /// True only when the source may safely be deleted.
     pub fn safe_to_delete_source(&self) -> bool {
-        self.exit_code() == EXIT_IDENTICAL && self.identical > 0
+        safe_to_delete_for(
+            self.identical,
+            self.differs.len(),
+            self.missing.len(),
+            self.extra.len(),
+            self.unreadable.len(),
+        )
     }
+}
+
+/// The exit-code decision, as a pure function of the counts.
+///
+/// Extracted from `Report` so it can be PROVED rather than sampled: `Report`
+/// carries `Vec`s, and a Kani harness that constructs one drags the allocator
+/// and `core::fmt` into the model — measured elsewhere in this fleet at 117
+/// minutes for a 216-case space. Over four `usize` counts the same property is
+/// exhaustive and instant.
+#[must_use]
+pub const fn exit_code_for(differs: usize, missing: usize, extra: usize, unreadable: usize) -> i32 {
+    if unreadable > 0 {
+        EXIT_UNREADABLE
+    } else if differs > 0 || missing > 0 || extra > 0 {
+        EXIT_DIFFERS
+    } else {
+        EXIT_IDENTICAL
+    }
+}
+
+/// Whether the source may be deleted, as a pure function of the counts.
+///
+/// `identical > 0` is not pedantry. Two empty trees produce all-zero counts and
+/// would otherwise authorise deleting a source on a comparison that examined
+/// nothing — a conclusion with no evidence under it, which is the same shape as
+/// a green test over an empty set.
+#[must_use]
+pub const fn safe_to_delete_for(
+    identical: usize,
+    differs: usize,
+    missing: usize,
+    extra: usize,
+    unreadable: usize,
+) -> bool {
+    identical > 0 && exit_code_for(differs, missing, extra, unreadable) == EXIT_IDENTICAL
 }
 
 /// One side's scan: fingerprints we got, and paths we could not read.
@@ -428,4 +468,61 @@ mod tests {
         assert_eq!(Outcome::Extra.token(), "extra");
         assert_eq!(Outcome::Unreadable.token(), "unreadable");
     }
+}
+
+// ── Kani: the decision that authorises destroying data ───────────────────
+//
+// These target `exit_code_for` / `safe_to_delete_for`, never `Report`. That is
+// the allocation-free boundary: `Report` carries `Vec`s, and modelling the
+// allocator to prove arithmetic over four counts buys nothing and costs hours.
+
+/// Any count, bounded so the model stays small. The properties below do not
+/// depend on magnitude — only on zero versus non-zero — so a bound of 3 covers
+/// every distinct case rather than sampling a large space.
+#[cfg(kani)]
+fn any_count() -> usize {
+    let n: usize = kani::any();
+    kani::assume(n <= 3);
+    n
+}
+
+/// A delete is NEVER authorised without positive evidence.
+///
+/// This is the safety property the whole command exists for. If it can be
+/// violated, copia can tell a caller to delete 755 GB on the strength of a
+/// comparison that found a difference, could not look, or examined nothing.
+#[cfg(kani)]
+#[kani::proof]
+fn verify_never_authorises_a_delete_without_positive_evidence() {
+    let (identical, differs, missing, extra, unreadable) = (
+        any_count(),
+        any_count(),
+        any_count(),
+        any_count(),
+        any_count(),
+    );
+    if safe_to_delete_for(identical, differs, missing, extra, unreadable) {
+        assert!(identical > 0, "authorised a delete having compared nothing");
+        assert!(differs == 0, "authorised a delete with known differences");
+        assert!(missing == 0, "authorised a delete with a missing path");
+        assert!(extra == 0, "authorised a delete with an unexpected path");
+        assert!(unreadable == 0, "authorised a delete over unreadable paths");
+    }
+}
+
+/// `unreadable` outranks `differs`, always.
+///
+/// Both refuse the delete, so collapsing them is tempting. They must not
+/// collapse: "I could not look" reported as "I looked and found a difference"
+/// is a claim about evidence we do not have.
+#[cfg(kani)]
+#[kani::proof]
+fn unreadable_is_never_reported_as_a_difference() {
+    let (differs, missing, extra, unreadable) =
+        (any_count(), any_count(), any_count(), any_count());
+    let code = exit_code_for(differs, missing, extra, unreadable);
+    if unreadable > 0 {
+        assert!(code == EXIT_UNREADABLE);
+    }
+    assert!(code == EXIT_IDENTICAL || code == EXIT_DIFFERS || code == EXIT_UNREADABLE);
 }

--- a/src/bin/copia/verify.rs
+++ b/src/bin/copia/verify.rs
@@ -1,0 +1,431 @@
+//! `copia verify` — prove two trees are byte-identical, changing nothing.
+//!
+//! # Why this exists
+//!
+//! copia is the Sovereign AI Stack's rsync replacement. Until this command it
+//! was that for *transfer* and not for *archival*, so the one operation where
+//! being wrong destroys data — move a tree, then delete the original — was
+//! still delegated to rsync. forjar's `nas_archive` moves 755 GB to the NAS and
+//! deletes the source, and it stayed on
+//! `rsync -a --checksum --dry-run --itemize-changes` purely because copia could
+//! not express that pass (copia#46).
+//!
+//! # The four guarantees, and why each is load-bearing
+//!
+//! 1. **Compares by CONTENT.** Never size+mtime. A file truncated in place with
+//!    its mtime preserved is exactly the corruption a quick-check misses, and it
+//!    is indistinguishable from a healthy file until you read the bytes.
+//!
+//! 2. **Provably read-only.** This runs against the destination that is about to
+//!    justify deleting the source. It opens files for reading and holds no write
+//!    handle anywhere; `verify_read_only_never_writes` asserts that by
+//!    fingerprinting both trees before and after a run and requiring both to be
+//!    unchanged, which catches a write this module does not even know it makes.
+//!
+//! 3. **Per-path outcome, machine-readable.** Three outcomes that must never
+//!    collapse: `identical`, `differs`, and `unreadable`. The third is the one
+//!    that matters — `discover_local_fingerprints` SKIPS a file it cannot read
+//!    ("never guessed"), which is right for sync and catastrophic here, because
+//!    a skipped file is absent from both maps and therefore reads as agreement.
+//!    A verifier that cannot tell "same" from "I could not look" is worse than
+//!    none: it produces a confident answer with no evidence behind it. That
+//!    failure has already happened downstream — `nas_archive`'s predecessor
+//!    printed `verified: 0 files differ` when the comparison itself had failed.
+//!
+//! 4. **Distinct exit codes.** A caller deleting 755 GB branches on these:
+//!
+//!    | code | meaning |
+//!    |---|---|
+//!    | 0 | identical — safe to delete the source |
+//!    | 1 | differences found — do not delete |
+//!    | 2 | could not compare — do not delete. NOT the same as 1: the tree may be perfect, and we have no evidence either way |
+//!    | 3 | usage or IO error before comparison began |
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use super::meta::fingerprint_path;
+use super::reconcile::Fingerprint;
+use super::transfer::discover_local_files;
+
+/// Exit codes. Public contract — a caller branches on these before deleting.
+pub const EXIT_IDENTICAL: i32 = 0;
+pub const EXIT_DIFFERS: i32 = 1;
+pub const EXIT_UNREADABLE: i32 = 2;
+pub const EXIT_ERROR: i32 = 3;
+
+/// What we concluded about one path.
+///
+/// `Identical` is never constructed internally — identical paths are counted,
+/// not listed, because printing 400,000 "identical" lines on a 755 GB tree
+/// buries the four that matter. It stays in the enum because the token set is a
+/// PUBLIC contract a caller may match on, and a variant that exists only when
+/// something happens to emit it is not a contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum Outcome {
+    Identical,
+    /// Present in both, content or entry type differs.
+    Differs,
+    /// Present in source, absent from destination.
+    Missing,
+    /// Present in destination, absent from source.
+    Extra,
+    /// Could not be read on one side or the other. NOT a difference, and
+    /// emphatically not agreement.
+    Unreadable,
+}
+
+impl Outcome {
+    /// The stable token emitted per path. Machine-readable; never localised.
+    pub const fn token(self) -> &'static str {
+        match self {
+            Self::Identical => "identical",
+            Self::Differs => "differs",
+            Self::Missing => "missing",
+            Self::Extra => "extra",
+            Self::Unreadable => "unreadable",
+        }
+    }
+}
+
+/// The verdict over a whole tree.
+#[derive(Debug, Default)]
+pub struct Report {
+    pub identical: usize,
+    pub differs: Vec<PathBuf>,
+    pub missing: Vec<PathBuf>,
+    pub extra: Vec<PathBuf>,
+    pub unreadable: Vec<PathBuf>,
+}
+
+impl Report {
+    /// Exit code for this report.
+    ///
+    /// `Unreadable` outranks `Differs` deliberately. Both refuse the delete, but
+    /// they mean different things and a caller may want to retry one and not the
+    /// other — and collapsing them would let "I could not look" be reported as
+    /// "I looked and found a difference", which is a claim we did not earn.
+    pub fn exit_code(&self) -> i32 {
+        if !self.unreadable.is_empty() {
+            EXIT_UNREADABLE
+        } else if !self.differs.is_empty() || !self.missing.is_empty() || !self.extra.is_empty() {
+            EXIT_DIFFERS
+        } else {
+            EXIT_IDENTICAL
+        }
+    }
+
+    /// True only when the source may safely be deleted.
+    pub fn safe_to_delete_source(&self) -> bool {
+        self.exit_code() == EXIT_IDENTICAL && self.identical > 0
+    }
+}
+
+/// One side's scan: fingerprints we got, and paths we could not read.
+struct Scan {
+    fps: std::collections::BTreeMap<PathBuf, Fingerprint>,
+    unreadable: BTreeSet<PathBuf>,
+}
+
+/// Fingerprint a tree, RECORDING failures instead of dropping them.
+///
+/// This is the one place this command deliberately does not reuse
+/// `discover_local_fingerprints`: that function skips what it cannot read, which
+/// is correct for sync (retry next run) and wrong here (a skipped file is absent
+/// from both maps and therefore looks like agreement).
+fn scan(root: &Path) -> Result<Scan, Box<dyn std::error::Error>> {
+    let mut fps = std::collections::BTreeMap::new();
+    let mut unreadable = BTreeSet::new();
+    for rel in discover_local_files(root)? {
+        match fingerprint_path(&root.join(&rel)) {
+            Ok(fp) => {
+                fps.insert(rel, fp);
+            }
+            Err(_) => {
+                unreadable.insert(rel);
+            }
+        }
+    }
+    Ok(Scan { fps, unreadable })
+}
+
+/// Compare two trees by content. Reads only.
+pub fn compare(src: &Path, dest: &Path) -> Result<Report, Box<dyn std::error::Error>> {
+    let source = scan(src)?;
+    let destination = scan(dest)?;
+    let mut report = Report::default();
+
+    // Anything unreadable on EITHER side taints that path. We do not know what
+    // is there, so we do not get to say.
+    for path in source
+        .unreadable
+        .iter()
+        .chain(destination.unreadable.iter())
+    {
+        if !report.unreadable.contains(path) {
+            report.unreadable.push(path.clone());
+        }
+    }
+
+    let all: BTreeSet<&PathBuf> = source.fps.keys().chain(destination.fps.keys()).collect();
+    for path in all {
+        if report.unreadable.contains(path) {
+            continue;
+        }
+        match (source.fps.get(path), destination.fps.get(path)) {
+            (Some(from), Some(to)) => {
+                if from == to {
+                    report.identical += 1;
+                } else {
+                    report.differs.push(path.clone());
+                }
+            }
+            (Some(_), None) => report.missing.push(path.clone()),
+            (None, Some(_)) => report.extra.push(path.clone()),
+            // Cannot occur — `all` is built from the two maps' keys. Treated as
+            // UNREADABLE rather than aborting: if the impossible happens in a
+            // verifier that authorises deleting 755 GB, the safe answer is
+            // "no evidence", not a panic and not silence.
+            (None, None) => report.unreadable.push(path.clone()),
+        }
+    }
+    report.differs.sort();
+    report.missing.sort();
+    report.extra.sort();
+    report.unreadable.sort();
+    Ok(report)
+}
+
+/// Run the command. Returns the process exit code.
+pub fn verify(src: &Path, dest: &Path, quiet: bool) -> i32 {
+    let report = match compare(src, dest) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("copia verify: cannot compare: {e}");
+            return EXIT_ERROR;
+        }
+    };
+
+    if !quiet {
+        // One line per non-identical path, token first so it is greppable and
+        // cut-able. Identical paths are not printed: on a 755 GB tree that is
+        // noise that hides the four lines that matter.
+        for (list, o) in [
+            (&report.differs, Outcome::Differs),
+            (&report.missing, Outcome::Missing),
+            (&report.extra, Outcome::Extra),
+            (&report.unreadable, Outcome::Unreadable),
+        ] {
+            for p in list {
+                println!("{}\t{}", o.token(), p.display());
+            }
+        }
+    }
+
+    eprintln!(
+        "copia verify: {} identical, {} differ, {} missing, {} extra, {} unreadable",
+        report.identical,
+        report.differs.len(),
+        report.missing.len(),
+        report.extra.len(),
+        report.unreadable.len()
+    );
+    // State the verdict the caller actually needs, in words, rather than making
+    // them re-derive it from five counts and an exit code. `safe_to_delete_source`
+    // is the single predicate that authorises destroying data; it belongs on the
+    // output, not only in a test.
+    if report.safe_to_delete_source() {
+        eprintln!("copia verify: trees are identical — the source may safely be deleted");
+    } else {
+        eprintln!("copia verify: DO NOT DELETE the source");
+    }
+    if report.exit_code() == EXIT_UNREADABLE {
+        eprintln!(
+            "copia verify: REFUSING to certify — {} path(s) could not be read. \
+             This is not a difference; it is an absence of evidence, and deleting \
+             a source on the strength of it is how data is lost.",
+            report.unreadable.len()
+        );
+    }
+    report.exit_code()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "copia-verify-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn write(root: &Path, rel: &str, body: &[u8]) {
+        let p = root.join(rel);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, body).unwrap();
+    }
+
+    #[test]
+    fn identical_trees_are_safe_to_delete() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        for r in [&a, &b] {
+            write(r, "x.txt", b"hello");
+            write(r, "deep/y.bin", &[0u8; 4096]);
+        }
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(rep.exit_code(), EXIT_IDENTICAL);
+        assert!(rep.safe_to_delete_source());
+        assert_eq!(rep.identical, 2);
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// THE case a size+mtime check misses: same length, same mtime, different
+    /// bytes. If this passes, the verifier is not comparing content.
+    #[test]
+    fn same_size_same_mtime_different_bytes_is_caught() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "f", b"AAAAAAAA");
+        write(&b, "f", b"BBBBBBBB");
+        // Force identical mtimes so ONLY content can distinguish the two files.
+        // `touch -r` rather than a `filetime` dev-dependency: adding a crate to
+        // a sovereign-stack tool for one test assertion is a poor trade, and
+        // this is a test-only shell-out with a checked outcome.
+        let _ = std::process::Command::new("touch")
+            .arg("-r")
+            .arg(a.join("f"))
+            .arg(b.join("f"))
+            .status();
+        assert_eq!(
+            fs::metadata(a.join("f")).unwrap().len(),
+            fs::metadata(b.join("f")).unwrap().len(),
+            "fixture must have equal sizes or it proves nothing"
+        );
+        // If `touch -r` was unavailable the mtimes may differ, and the test then
+        // proves the weaker (still necessary) claim: equal size, different bytes
+        // is caught. Say which was proved rather than implying the stronger one.
+        let same_mtime = fs::metadata(a.join("f")).unwrap().modified().ok()
+            == fs::metadata(b.join("f")).unwrap().modified().ok();
+        if !same_mtime {
+            eprintln!("note: mtimes differ; this run proves equal-size/different-bytes only");
+        }
+
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(rep.exit_code(), EXIT_DIFFERS);
+        assert!(!rep.safe_to_delete_source());
+        assert_eq!(rep.differs.len(), 1);
+        fs::remove_dir_all(&t).ok();
+    }
+
+    #[test]
+    fn a_missing_file_is_not_identical() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "keep", b"1");
+        write(&a, "lost", b"2");
+        write(&b, "keep", b"1");
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(rep.exit_code(), EXIT_DIFFERS);
+        assert_eq!(rep.missing, vec![PathBuf::from("lost")]);
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// Guarantee 4. "I could not look" must not be reported as "I looked and
+    /// found a difference", and must never be reported as agreement.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_file_refuses_certification_with_its_own_code() {
+        use std::os::unix::fs::PermissionsExt;
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "secret", b"same");
+        write(&b, "secret", b"same");
+        // Unreadable on the DESTINATION side — the side about to justify a delete.
+        fs::set_permissions(b.join("secret"), fs::Permissions::from_mode(0o000)).unwrap();
+
+        let rep = compare(&a, &b).unwrap();
+        // Running as root defeats chmod; skip rather than assert a false thing.
+        if rep.unreadable.is_empty() {
+            fs::set_permissions(b.join("secret"), fs::Permissions::from_mode(0o644)).ok();
+            fs::remove_dir_all(&t).ok();
+            return;
+        }
+        assert_eq!(
+            rep.exit_code(),
+            EXIT_UNREADABLE,
+            "must not be 0 and must not be 1"
+        );
+        assert!(!rep.safe_to_delete_source());
+        assert!(rep.differs.is_empty(), "unreadable is not a difference");
+        assert_eq!(
+            rep.identical, 0,
+            "an unreadable path must not be counted identical"
+        );
+
+        fs::set_permissions(b.join("secret"), fs::Permissions::from_mode(0o644)).ok();
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// Guarantee 2, asserted rather than asserted-about: fingerprint both trees
+    /// before and after a run and require both unchanged. This catches a write
+    /// the module does not know it makes, which a code review cannot.
+    #[test]
+    fn verify_read_only_never_writes() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "x", b"one");
+        write(&a, "y/z", b"two");
+        write(&b, "x", b"one");
+        write(&b, "y/z", b"DIFFERENT");
+
+        let before_a = scan(&a).unwrap().fps;
+        let before_b = scan(&b).unwrap().fps;
+        let code = verify(&a, &b, true);
+        assert_eq!(code, EXIT_DIFFERS);
+        let after_a = scan(&a).unwrap().fps;
+        let after_b = scan(&b).unwrap().fps;
+
+        assert_eq!(before_a, after_a, "verify modified the SOURCE tree");
+        assert_eq!(before_b, after_b, "verify modified the DESTINATION tree");
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// An empty comparison must not read as success. Two empty trees are
+    /// "identical" in the trivial sense, and deleting a source on that basis is
+    /// the vacuous-green shape: nothing was compared, so nothing was proved.
+    #[test]
+    fn two_empty_trees_are_not_safe_to_delete() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        fs::create_dir_all(&a).unwrap();
+        fs::create_dir_all(&b).unwrap();
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(rep.identical, 0);
+        assert!(
+            !rep.safe_to_delete_source(),
+            "a comparison that examined nothing must not authorise a deletion"
+        );
+        fs::remove_dir_all(&t).ok();
+    }
+
+    #[test]
+    fn outcome_tokens_are_stable() {
+        assert_eq!(Outcome::Identical.token(), "identical");
+        assert_eq!(Outcome::Differs.token(), "differs");
+        assert_eq!(Outcome::Missing.token(), "missing");
+        assert_eq!(Outcome::Extra.token(), "extra");
+        assert_eq!(Outcome::Unreadable.token(), "unreadable");
+    }
+}

--- a/src/bin/copia/verify.rs
+++ b/src/bin/copia/verify.rs
@@ -460,6 +460,101 @@ mod tests {
         fs::remove_dir_all(&t).ok();
     }
 
+    /// The non-quiet path prints one line per non-identical path. Untested
+    /// until now, which meant the ONLY output an operator actually reads was
+    /// the part with no test behind it.
+    #[test]
+    fn the_per_path_report_is_emitted_and_the_verdict_refuses() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "gone", b"1");
+        write(&a, "changed", b"one");
+        write(&b, "changed", b"two");
+        write(&b, "unexpected", b"3");
+
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(rep.missing, vec![PathBuf::from("gone")]);
+        assert_eq!(rep.differs, vec![PathBuf::from("changed")]);
+        assert_eq!(rep.extra, vec![PathBuf::from("unexpected")]);
+        assert!(!rep.safe_to_delete_source());
+
+        // The printing path itself must not panic and must not change the code.
+        assert_eq!(verify(&a, &b, false), EXIT_DIFFERS);
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// A path present only at the DESTINATION is not harmless. It means the
+    /// destination is not a faithful copy, and a caller about to delete the
+    /// source is entitled to know before it does.
+    #[test]
+    fn an_extra_file_at_the_destination_refuses_the_delete() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "shared", b"x");
+        write(&b, "shared", b"x");
+        write(&b, "stowaway", b"y");
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(rep.exit_code(), EXIT_DIFFERS);
+        assert_eq!(rep.extra, vec![PathBuf::from("stowaway")]);
+        assert!(!rep.safe_to_delete_source());
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// A source that cannot be walked is an ERROR, distinct from every verdict.
+    /// Returning 1 here would tell a caller "I compared them and they differ",
+    /// which is a claim about a comparison that never happened.
+    #[test]
+    fn an_unwalkable_source_is_exit_3_not_a_verdict() {
+        let t = tmp();
+        let missing = t.join("does-not-exist");
+        let dest = t.join("dest");
+        fs::create_dir_all(&dest).unwrap();
+        assert_eq!(verify(&missing, &dest, true), EXIT_ERROR);
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// A file replaced by a symlink whose target string happens to hash to the
+    /// same bytes must still be a difference. Type is part of identity.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_to_symlink_flip_is_a_difference() {
+        let t = tmp();
+        let (a, b) = (t.join("a"), t.join("b"));
+        write(&a, "thing", b"target.txt");
+        write(&a, "target.txt", b"payload");
+        write(&b, "target.txt", b"payload");
+        std::os::unix::fs::symlink("target.txt", b.join("thing")).unwrap();
+
+        let rep = compare(&a, &b).unwrap();
+        assert_eq!(
+            rep.differs,
+            vec![PathBuf::from("thing")],
+            "a regular file and a symlink are different entries even when the \
+             hashed bytes coincide"
+        );
+        fs::remove_dir_all(&t).ok();
+    }
+
+    /// The pure decision, exercised over the whole shape space the Kani harness
+    /// proves. Kani proves it holds; this pins the exact codes so a renumbering
+    /// is a test failure and not a silent contract change.
+    #[test]
+    fn the_pure_decision_matches_the_published_codes() {
+        assert_eq!(exit_code_for(0, 0, 0, 0), EXIT_IDENTICAL);
+        assert_eq!(exit_code_for(1, 0, 0, 0), EXIT_DIFFERS);
+        assert_eq!(exit_code_for(0, 1, 0, 0), EXIT_DIFFERS);
+        assert_eq!(exit_code_for(0, 0, 1, 0), EXIT_DIFFERS);
+        assert_eq!(exit_code_for(0, 0, 0, 1), EXIT_UNREADABLE);
+        // unreadable outranks every other failure, together or alone
+        assert_eq!(exit_code_for(9, 9, 9, 1), EXIT_UNREADABLE);
+        assert!(safe_to_delete_for(1, 0, 0, 0, 0));
+        assert!(!safe_to_delete_for(0, 0, 0, 0, 0), "examined nothing");
+        assert!(
+            !safe_to_delete_for(99, 0, 0, 0, 1),
+            "one unreadable path is enough"
+        );
+    }
+
     #[test]
     fn outcome_tokens_are_stable() {
         assert_eq!(Outcome::Identical.token(), "identical");

--- a/tests/rsync_differential.rs
+++ b/tests/rsync_differential.rs
@@ -1,0 +1,352 @@
+//! Differential harness: copia against rsync, on the shapes that matter.
+//!
+//! copia claims to replace rsync for archival — move a tree, prove it landed,
+//! delete the original. A claim that large is not settled by copia agreeing with
+//! itself. So every case here runs BOTH tools over the same fixture and requires
+//! the results to agree, with rsync as the oracle:
+//!
+//! * `rsync -a src/ dst/` vs `copia sync -r src dst` — the destinations must be
+//!   indistinguishable in structure, content, symlink-ness, and link targets.
+//! * `rsync -a --checksum --dry-run --itemize-changes` vs `copia verify` — the
+//!   two must agree on whether the trees match, because that verdict is what
+//!   authorises deleting 755 GB.
+//!
+//! # Why rsync must be PRESENT, not skipped around
+//!
+//! An absent oracle makes every case here vacuously green. That failure has
+//! already been paid for downstream: forjar's `nas_archive` suite reported PASS
+//! on seven tests while none of them ran, because rsync was missing and each
+//! test skipped with an `eprintln!` that nextest hides for passing tests. So
+//! `the_oracle_is_present` FAILS rather than skips, and CI must install rsync.
+//!
+//! # Shapes chosen because they have broken something
+//!
+//! Symlink-to-directory is first for a reason: `copia sync -r` silently DROPPED
+//! it (the walk excluded it from directories and it was not a file), and because
+//! `copia verify` shared that walk, the path was absent from both scans and the
+//! trees compared IDENTICAL. copia reported success over data it had just lost.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::similar_names
+)]
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn copia_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_copia"))
+}
+
+fn have_rsync() -> bool {
+    Command::new("rsync")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn tmp(tag: &str) -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "copia-diff-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn write(root: &Path, rel: &str, body: &[u8]) {
+    let p = root.join(rel);
+    if let Some(parent) = p.parent() {
+        fs::create_dir_all(parent).expect("mkdir -p");
+    }
+    fs::write(p, body).expect("write");
+}
+
+/// A comparable description of one tree: every entry, its kind, and either its
+/// content hash or its link target. Deliberately NOT a byte-for-byte metadata
+/// dump — mtimes and owners are a separate concern and would make every case
+/// fail for reasons unrelated to what it is testing.
+fn describe(root: &Path) -> Vec<String> {
+    fn walk(root: &Path, dir: &Path, out: &mut Vec<String>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        let mut items: Vec<_> = entries.flatten().map(|e| e.path()).collect();
+        items.sort();
+        for p in items {
+            let rel = p
+                .strip_prefix(root)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .to_string();
+            let Ok(md) = fs::symlink_metadata(&p) else {
+                continue;
+            };
+            if md.file_type().is_symlink() {
+                let target = fs::read_link(&p).unwrap_or_default();
+                out.push(format!("symlink\t{rel}\t{}", target.display()));
+            } else if md.is_dir() {
+                out.push(format!("dir\t{rel}"));
+                walk(root, &p, out);
+            } else {
+                let body = fs::read(&p).unwrap_or_default();
+                out.push(format!("file\t{rel}\t{}", blake3::hash(&body).to_hex()));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out
+}
+
+fn rsync_to(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("mkdir dst");
+    let out = Command::new("rsync")
+        .arg("-a")
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .output()
+        .expect("spawn rsync");
+    assert!(
+        out.status.success(),
+        "rsync failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn copia_to(src: &Path, dst: &Path) {
+    let out = Command::new(copia_bin())
+        .args(["sync", "-r"])
+        .arg(src)
+        .arg(dst)
+        .output()
+        .expect("spawn copia");
+    assert!(
+        out.status.success(),
+        "copia sync failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// rsync's verdict on whether two trees already match, by CONTENT.
+/// Empty itemised output means nothing would change — the trees agree.
+fn rsync_says_identical(src: &Path, dst: &Path) -> bool {
+    let out = Command::new("rsync")
+        .args(["-a", "--checksum", "--dry-run", "--itemize-changes"])
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .output()
+        .expect("spawn rsync");
+    String::from_utf8_lossy(&out.stdout).trim().is_empty()
+}
+
+fn copia_says_identical(src: &Path, dst: &Path) -> bool {
+    let out = Command::new(copia_bin())
+        .args(["verify", "-q"])
+        .arg(src)
+        .arg(dst)
+        .output()
+        .expect("spawn copia verify");
+    out.status.code() == Some(0)
+}
+
+/// Build one fixture shape into `root`.
+fn build_fixture(shape: &str, root: &Path) {
+    match shape {
+        "plain-files" => {
+            write(root, "a.txt", b"alpha");
+            write(root, "b.bin", &[7u8; 10_000]);
+        }
+        "nested-dirs" => {
+            write(root, "one/two/three/deep.txt", b"deep");
+            write(root, "one/sibling.txt", b"sib");
+        }
+        "symlink-to-file" => {
+            write(root, "real.txt", b"real");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink("real.txt", root.join("link.txt")).expect("symlink");
+        }
+        // FIRST because it is the one that silently lost data.
+        "symlink-to-dir" => {
+            write(root, "realdir/inside.txt", b"inside");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink("realdir", root.join("dirlink")).expect("symlink");
+        }
+        "dangling-symlink" => {
+            #[cfg(unix)]
+            std::os::unix::fs::symlink("nowhere.txt", root.join("dangling")).expect("symlink");
+            write(root, "present.txt", b"present");
+        }
+        "empty-dir" => {
+            fs::create_dir_all(root.join("hollow")).expect("mkdir");
+            write(root, "beside.txt", b"beside");
+        }
+        "awkward-names" => {
+            write(root, "with space.txt", b"space");
+            write(root, "unicode-\u{00e9}\u{4e2d}.txt", b"unicode");
+            write(root, "dash-leading/-weird.txt", b"dash");
+        }
+        "large-file" => {
+            write(root, "big.bin", &vec![3u8; 3 * 1024 * 1024]);
+        }
+        other => panic!("unknown fixture shape: {other}"),
+    }
+}
+
+const SHAPES: &[&str] = &[
+    "symlink-to-dir",
+    "symlink-to-file",
+    "dangling-symlink",
+    "plain-files",
+    "nested-dirs",
+    "empty-dir",
+    "awkward-names",
+    "large-file",
+];
+
+/// The oracle must exist. An absent rsync makes every case below vacuous, and
+/// this suite would report PASS while proving nothing — the exact failure that
+/// has already happened in this fleet.
+#[test]
+fn the_oracle_is_present() {
+    assert!(
+        have_rsync(),
+        "rsync is not installed, so every differential case in this file would \
+         compare copia against nothing and pass. Install rsync in CI; do not \
+         convert these into skips."
+    );
+}
+
+/// copia sync must produce what rsync -a produces.
+#[test]
+fn copia_sync_matches_rsync_on_every_shape() {
+    if !have_rsync() {
+        return; // the_oracle_is_present already fails; do not double-report
+    }
+    let mut failures = Vec::new();
+    for shape in SHAPES {
+        let base = tmp(shape);
+        let (src, r, c) = (base.join("src"), base.join("rsync"), base.join("copia"));
+        fs::create_dir_all(&src).expect("mkdir src");
+        build_fixture(shape, &src);
+
+        rsync_to(&src, &r);
+        copia_to(&src, &c);
+
+        let (dr, dc) = (describe(&r), describe(&c));
+        if dr != dc {
+            failures.push(format!(
+                "shape `{shape}`:\n     rsync -> {dr:?}\n     copia -> {dc:?}"
+            ));
+        }
+        fs::remove_dir_all(&base).ok();
+    }
+    assert!(
+        failures.is_empty(),
+        "copia sync diverged from rsync -a on {} shape(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+/// copia verify must agree with rsync's own content comparison — in BOTH
+/// directions. Agreeing only when trees match would be satisfied by a verifier
+/// that always says "identical".
+#[test]
+fn copia_verify_agrees_with_rsync_checksum_both_ways() {
+    if !have_rsync() {
+        return;
+    }
+    let mut failures = Vec::new();
+    for shape in SHAPES {
+        let base = tmp(&format!("v-{shape}"));
+        let (src, dst) = (base.join("src"), base.join("dst"));
+        fs::create_dir_all(&src).expect("mkdir src");
+        build_fixture(shape, &src);
+        rsync_to(&src, &dst);
+
+        // 1. After a faithful copy, both must say identical.
+        let (r_same, c_same) = (
+            rsync_says_identical(&src, &dst),
+            copia_says_identical(&src, &dst),
+        );
+        if !(r_same && c_same) {
+            failures.push(format!(
+                "shape `{shape}` after rsync -a: rsync_identical={r_same} copia_identical={c_same}"
+            ));
+        }
+
+        // 2. Perturb one byte WITHOUT changing size, and both must say differ.
+        //    Equal size is the point: a size+mtime check would miss it.
+        let victim = fs::read_dir(&dst)
+            .expect("read dst")
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                fs::symlink_metadata(p)
+                    .map(|m| m.is_file())
+                    .unwrap_or(false)
+                    && fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false)
+            });
+        if let Some(v) = victim {
+            let mut body = fs::read(&v).expect("read victim");
+            let before = body.len();
+            body[0] ^= 0xFF;
+            fs::write(&v, &body).expect("write victim");
+            assert_eq!(
+                before as u64,
+                fs::metadata(&v).expect("stat").len(),
+                "the edit must preserve size or it proves nothing about content comparison"
+            );
+
+            let (r_diff, c_diff) = (
+                !rsync_says_identical(&src, &dst),
+                !copia_says_identical(&src, &dst),
+            );
+            if !(r_diff && c_diff) {
+                failures.push(format!(
+                    "shape `{shape}` after a 1-byte same-size edit: rsync_differs={r_diff} \
+                     copia_differs={c_diff} — a verifier that misses this authorises \
+                     deleting a corrupted source"
+                ));
+            }
+        }
+        fs::remove_dir_all(&base).ok();
+    }
+    assert!(
+        failures.is_empty(),
+        "copia verify disagreed with rsync on {} case(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+/// Falsification: the harness must be able to SEE a divergence. If `describe`
+/// cannot distinguish a symlink from a regular file, `copia_sync_matches_rsync`
+/// passes over the exact defect this file was written for.
+#[test]
+fn the_harness_can_see_a_symlink_divergence() {
+    let base = tmp("falsify");
+    let (a, b) = (base.join("a"), base.join("b"));
+    write(&a, "real.txt", b"same");
+    write(&b, "real.txt", b"same");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("real.txt", a.join("link")).expect("symlink");
+    // b gets a COPY where a has a link — byte-identical content, different tree.
+    write(&b, "link", b"same");
+
+    let (da, db) = (describe(&a), describe(&b));
+    assert_ne!(
+        da, db,
+        "describe() cannot tell a symlink from a regular file with the same \
+         content, so every comparison in this file is blind to the defect it exists to catch"
+    );
+    fs::remove_dir_all(&base).ok();
+}


### PR DESCRIPTION
copia is the Sovereign AI Stack’s rsync replacement. Until this it was that for **transfer** and not for **archival** — so the one operation where being wrong destroys data (move a tree, then delete the original) was still delegated to rsync. forjar’s `nas_archive` moves 755 GB to the NAS and deletes the source.

## `copia verify <src> <dest>`

| exit | meaning |
|---|---|
| 0 | identical — safe to delete the source |
| 1 | differences found |
| 2 | **could not compare** — not the same as 1 |
| 3 | error before comparing |

Compares by **content**, is **provably read-only**, and keeps `unreadable` as its own outcome. A verifier that cannot tell *"same"* from *"I could not look"* produces a confident answer with no evidence behind it — and that has already happened downstream, where `nas_archive`’s predecessor printed `verified: 0 files differ` when the comparison itself had failed.

## The harness found three data-loss bugs on its first run

Adding rsync as a differential oracle was the right call, because copia agreeing with itself proves nothing:

| shape | rsync -a | copia (before) |
|---|---|---|
| **symlink → directory** | recreated | **silently dropped** |
| dangling symlink | recreated | dropped |
| empty directory | preserved | dropped |

The first is the serious one. `discover_local_files` excluded symlinked dirs (`is_dir() && !is_symlink()`) and they failed `is_file()` too, so they left the walk entirely. **`copia verify` shares that walk** — so the path was absent from both scans and the trees compared **identical**. copia returned exit 0, *safe to delete*, over data it had just destroyed.

All three share one assumption — *"a tree is its files"*. Fixed at the root: symlinks classified before `is_dir`/`is_file` (both follow links), `symlink_metadata` so dangling links are stated not dropped, real directory discovery so empty dirs survive, and `deliver_local` recreating links instead of dereferencing them.

`deliver_local` deliberately does **not** set mtime on a symlink: `utimes` follows the link and would stamp the *target*. rsync needs `-h` for the same reason.

## Contract

`contracts/verify-before-delete-v1.yaml` — `pv validate`: **0 errors, 0 warnings**. Five equations, six falsification tests, two Kani harnesses, both **PROVED** and falsified (weakening `safe_to_delete_for` to ignore `unreadable` → `VERIFICATION:- FAILED`).

The harnesses target `exit_code_for`/`safe_to_delete_for`, extracted as pure functions *so they could be proved* — `Report` carries `Vec`s and modelling the allocator for arithmetic over four counts costs hours for nothing.

**Three obligations are marked proved by execution, not Kani**, and the contract says why: whether a run wrote anything, whether blake3 distinguishes equal-size files, and whether copia matches rsync are properties of the filesystem. Claiming Kani proofs for those would be the defect forjar#250 catalogued ten instances of.

`the_oracle_is_present` **fails** rather than skips — an absent rsync makes every case vacuous, which is how seven tests once reported PASS while none ran. **CI must install rsync.**

## Verified

365 tests pass, 0 fail. fmt clean, `clippy --all-targets -D warnings` clean. Dogfooded against the built binary on all 8 shapes.

Next: forjar’s `nas_archive` migrates onto this, and its rsync entry in the sovereign sync-tool partition becomes a deletion rather than debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf