### PR TITLE
fix(plan): flatten is_excluded — cognitive complexity 33 blocked the v0.3.0 release gate

### DIFF
--- a/src/bin/copia/plan.rs
+++ b/src/bin/copia/plan.rs
@@ -78,26 +78,35 @@ pub fn needs_transfer(src: FileMeta, dst: Option<FileMeta>) -> bool {
 /// accepted as the same); a pattern containing `/` matches the whole relative
 /// path as a glob.
 pub fn is_excluded(rel: &Path, excludes: &[String]) -> bool {
-    for pat in excludes {
-        let pat = pat.trim_end_matches('/');
-        if pat.is_empty() {
-            continue;
-        }
-        if pat.contains('/') {
-            if glob_match(pat, &rel.to_string_lossy()) {
-                return true;
-            }
-        } else {
-            for comp in rel.components() {
-                if let Component::Normal(c) = comp {
-                    if glob_match(pat, &c.to_string_lossy()) {
-                        return true;
-                    }
-                }
-            }
-        }
+    excludes
+        .iter()
+        .any(|pat| pattern_matches(pat.trim_end_matches('/'), rel))
+}
+
+/// One pattern against one path. Split out of `is_excluded` because cognitive
+/// complexity punishes NESTING, not branch count: the original was
+/// `for -> if -> if/else -> for -> if -> if`, six levels deep, scoring 33
+/// against a threshold of 25 and blocking the v0.3.0 release gate. The branches
+/// are all still here — they are just no longer stacked inside one another.
+fn pattern_matches(pat: &str, rel: &Path) -> bool {
+    if pat.is_empty() {
+        return false;
     }
-    false
+    if pat.contains('/') {
+        // A pattern with a slash is matched against the WHOLE relative path.
+        return glob_match(pat, &rel.to_string_lossy());
+    }
+    matches_any_component(pat, rel)
+}
+
+/// A slashless pattern prunes anywhere in the tree, so it is matched against
+/// each path COMPONENT. Non-`Normal` components (`.`, `..`, root, prefix) can
+/// never match a user pattern and are skipped rather than stringified.
+fn matches_any_component(pat: &str, rel: &Path) -> bool {
+    rel.components().any(|comp| match comp {
+        Component::Normal(c) => glob_match(pat, &c.to_string_lossy()),
+        _ => false,
+    })
 }
 
 /// Classic wildcard match with backtracking: `*` matches any run of characters,


### PR DESCRIPTION
The v0.3.0 release failed at `gate / lint-gate` → `L4: pmat quality-gate`:

```
./src/bin/copia/plan.rs:80 - is_excluded: cognitive-complexity
Cognitive complexity of 33 exceeds maximum allowed complexity of 25
```

`create-release` had already succeeded, so **the GitHub release exists while `publish` was skipped** — the tag points at something that never reached crates.io.

## The problem is nesting, not branches

Ten branches is fine. Cognitive complexity punishes **depth**, and this was six levels:

```
for pat -> if empty -> if contains(/) -> if glob -> else -> for comp
  -> if let Normal -> if glob
```

Split into three functions with the same branches, no longer stacked. Behaviour identical: first match wins, trailing slash trimmed, empty pattern skipped, non-`Normal` components skipped rather than stringified.

## Why it surfaced now

`release.yml` had not run successfully since **2026-07-04**. A gate that never runs accumulates exactly this — the defect was reachable for seven weeks and nothing looked.

## The other five are also being fixed

`pmat.toml` sets cognitive **20**; CI uses 25. Five more functions sit at 20–23 — under CI’s bar, over the repo’s own:

```
src/async_sync.rs:145        delta                 23
src/sync.rs:39               delta                 23
src/signature.rs:274         find_match_optimized  23
src/bin/copia/bidir.rs:141   apply                 21
src/bin/copia/incremental.rs:118  run_remote       20
```

Calling those "pre-existing and under CI’s threshold" would be picking the looser of two numbers the repo publishes about itself, which is how a limit becomes decorative. They are in scope here.

## Verified with the CI invocation, not a proxy

`pmat quality-gate --fail-on-violation --max-dead-code 15.0 --max-complexity-p99 50` — `is_excluded` no longer appears even at the stricter local threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf