### PR TITLE
fix(complexity): flatten the five functions over copia's OWN cognitive limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | `hub-sync` | **L3** — hub client | Pushes a local tree to a hub (`host:root` over SSH, or a local hub path) over one persistent connection. CAS concurrency safety: N clients → 1 hub, a stale write lands a conflict-copy, never a lost update. |
 | `signature` / `delta` / `patch` | primitives | The rsync delta primitives, usable standalone: generate a block signature, compute a delta against it, apply the delta to reconstruct a file. |
 
-## Install
+## Installation
 
 ```bash
 cargo install copia --features cli
@@ -40,7 +40,9 @@ cargo install copia --features cli
 
 The `cli` feature builds the `copia` binary (it pulls in `async` + `tracing`). To embed the delta-transfer engine as a **library**, add `copia = "0.1"` (with `features = ["async"]` for the tokio engine) — see [docs.rs/copia](https://docs.rs/copia).
 
-## Quick start
+## Usage
+
+Every example below is a real command; none is pseudocode.
 
 ### L1 — incremental one-way sync (`sync`)
 
@@ -133,6 +135,36 @@ Enforce it all with `make contracts`. Details in **[docs/proofs.md](docs/proofs.
 - **[docs/usage.md](docs/usage.md)** — full command reference and worked examples.
 - **[docs/specifications/rsync-copia-spec.md](docs/specifications/rsync-copia-spec.md)** — the L1 rsync-engine specification.
 - **[docs/specifications/distributed-sync.md](docs/specifications/distributed-sync.md)** — the L2/L3 distributed-sync specification (quorum-vetted against Unison, Syncthing, git, Dynamo/Cassandra, etcd, rsync).
+
+## Contributing
+
+copia is part of the Sovereign AI Stack. Two things are worth knowing before you
+open a PR, because both will fail your build otherwise.
+
+**Every claim needs a falsifier.** A test that has never failed has not been
+shown to test anything. When you add a check, also show the injection that makes
+it fail — the differential harness in `tests/rsync_differential.rs` does this
+explicitly: `the_oracle_is_present` FAILS rather than skips when rsync is
+missing, because an absent oracle makes every case in that file vacuously green.
+
+**Gates are not advisory.**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --features cli -- -D warnings
+cargo test --features cli
+pmat quality-gate --fail-on-violation --max-dead-code 15.0 --max-complexity-p99 50
+pv validate contracts/*.yaml          # binding.yaml is a manifest, not a contract
+```
+
+`pmat.toml` sets cognitive complexity to **20**. If a function trips it, flatten
+the nesting rather than deleting branches — cognitive complexity scores depth,
+not branch count, and merging cases to get under the number changes behaviour.
+
+Contracts in `contracts/` bind each equation to the function implementing it
+(`contracts/binding.yaml`), and `pv proof-status --binding` checks the function
+actually exists — so renaming one drops the contract a level rather than leaving
+a citation pointing at nothing.
 
 ## License
 

--- a/src/async_sync.rs
+++ b/src/async_sync.rs
@@ -172,39 +172,7 @@ impl AsyncCopiaSync {
             return Ok(delta);
         }
 
-        let mut pos = 0usize;
-
-        // Initialize fast rolling checksum with first block
-        let init_len = block_size.min(source_data.len());
-        let mut rolling = FastRollingChecksum::new(&source_data[..init_len]);
-
-        while pos + block_size <= source_data.len() {
-            let weak = rolling.digest();
-
-            // Fast path: check weak hash first before computing strong hash
-            if table.has_weak_match(weak) {
-                let block_data = &source_data[pos..pos + block_size];
-                if let Some(sig) = table.find_match(weak, block_data) {
-                    let offset = u64::from(sig.index) * block_size as u64;
-                    delta.push_copy(offset, block_size as u32);
-                    pos += block_size;
-
-                    // Re-initialize rolling checksum for next window
-                    if pos + block_size <= source_data.len() {
-                        rolling = FastRollingChecksum::new(&source_data[pos..pos + block_size]);
-                    }
-                    continue;
-                }
-            }
-
-            // No match - emit literal byte and roll window
-            delta.push_literal_byte(source_data[pos]);
-
-            if pos + block_size < source_data.len() {
-                rolling.roll(source_data[pos], source_data[pos + block_size]);
-            }
-            pos += 1;
-        }
+        let pos = scan_blocks(&table, &source_data, block_size, &mut delta);
 
         if pos < source_data.len() {
             delta.push_literal(&source_data[pos..]);
@@ -383,6 +351,75 @@ impl AsyncCopiaSync {
     }
 }
 
+/// Look up the block at `pos` in the signature table.
+///
+/// Checks the weak (rolling) hash first and only computes the strong hash when
+/// the weak hash has candidates. Returns the basis-file offset of the matching
+/// block, or `None` when the block does not match.
+#[cfg(feature = "async")]
+#[allow(clippy::cast_possible_truncation)] // block_size validated to be <= 65536
+fn match_block_at(
+    table: &SignatureTable,
+    source_data: &[u8],
+    pos: usize,
+    block_size: usize,
+    weak: u32,
+) -> Option<u64> {
+    // Fast path: check weak hash first before computing strong hash
+    if !table.has_weak_match(weak) {
+        return None;
+    }
+
+    let block_data = &source_data[pos..pos + block_size];
+    let sig = table.find_match(weak, block_data)?;
+    Some(u64::from(sig.index) * block_size as u64)
+}
+
+/// Scan `source_data` for blocks present in `table`, pushing copy and literal
+/// ops onto `delta`.
+///
+/// Returns the position of the first byte not yet emitted; the caller flushes
+/// the trailing remainder (shorter than one block) as a literal.
+#[cfg(feature = "async")]
+#[allow(clippy::cast_possible_truncation)] // block_size validated to be <= 65536
+fn scan_blocks(
+    table: &SignatureTable,
+    source_data: &[u8],
+    block_size: usize,
+    delta: &mut Delta,
+) -> usize {
+    let mut pos = 0usize;
+
+    // Initialize fast rolling checksum with first block
+    let init_len = block_size.min(source_data.len());
+    let mut rolling = FastRollingChecksum::new(&source_data[..init_len]);
+
+    while pos + block_size <= source_data.len() {
+        let weak = rolling.digest();
+
+        if let Some(offset) = match_block_at(table, source_data, pos, block_size, weak) {
+            delta.push_copy(offset, block_size as u32);
+            pos += block_size;
+
+            // Re-initialize rolling checksum for next window
+            if pos + block_size <= source_data.len() {
+                rolling = FastRollingChecksum::new(&source_data[pos..pos + block_size]);
+            }
+            continue;
+        }
+
+        // No match - emit literal byte and roll window
+        delta.push_literal_byte(source_data[pos]);
+
+        if pos + block_size < source_data.len() {
+            rolling.roll(source_data[pos], source_data[pos + block_size]);
+        }
+        pos += 1;
+    }
+
+    pos
+}
+
 impl Default for AsyncCopiaSync {
     fn default() -> Self {
         Self::new()
@@ -472,6 +509,29 @@ mod tests {
         let delta = sync.delta(Cursor::new(&data), &sig).await.unwrap();
 
         assert_eq!(delta.bytes_matched(), 1024);
+        assert_eq!(delta.bytes_literal(), 0);
+    }
+
+    /// Block-aligned source whose blocks differ from one another.
+    ///
+    /// After the last match `pos + block_size == source_data.len()` exactly, so
+    /// the scan loop runs one final iteration and must read a freshly seeded
+    /// rolling window. `async_delta_identical` cannot catch a stale window
+    /// because its data is uniform (every window has the same digest); distinct
+    /// per-block content makes a missed re-seed show up as literal bytes.
+    #[tokio::test]
+    async fn async_delta_block_aligned_distinct_blocks_is_all_copies() {
+        let sync = AsyncCopiaSync::with_block_size(512);
+        let mut data = Vec::new();
+        for b in 0u8..4 {
+            data.extend(vec![b.wrapping_mul(37).wrapping_add(1); 512]);
+        }
+        assert_eq!(data.len(), 2048);
+
+        let sig = sync.signature(Cursor::new(&data)).await.unwrap();
+        let delta = sync.delta(Cursor::new(&data), &sig).await.unwrap();
+
+        assert_eq!(delta.bytes_matched(), 2048);
         assert_eq!(delta.bytes_literal(), 0);
     }
 

--- a/src/bin/copia/bidir.rs
+++ b/src/bin/copia/bidir.rs
@@ -11,7 +11,7 @@
 
 use super::archive::{archive_path, root_pair_hash, Archive};
 use super::meta::discover_local_fingerprints;
-use super::reconcile::{reconcile, Action, ConflictKind, FpMap};
+use super::reconcile::{reconcile, Action, ConflictKind, Fingerprint, FpMap};
 use std::path::{Path, PathBuf};
 
 pub struct BidirOptions {
@@ -137,6 +137,97 @@ pub fn run_bisync(
     }
 }
 
+/// Record `rel`'s fingerprint, as seen on `side`, into the new common base.
+///
+/// A no-op when `side` does not hold `rel` — the caller's base entry (if any) is
+/// then left exactly as it was, which is what the inlined `if let` did.
+fn record_common(common: &mut FpMap, side: &FpMap, rel: &Path) {
+    if let Some(fp) = side.get(rel) {
+        common.insert(rel.to_path_buf(), *fp);
+    }
+}
+
+/// Delete-vs-modify: keep the modification by restoring the surviving side onto
+/// the deleted one.
+///
+/// A is probed FIRST and `b` is consulted only when A does not hold `rel`; that
+/// order is the arm's own, and it is load-bearing — with both sides present the
+/// A->B copy is the one that must run.
+fn apply_delete_vs_modify(
+    pa: &Path,
+    pb: &Path,
+    rel: &Path,
+    a: &FpMap,
+    b: &FpMap,
+    common: &mut FpMap,
+) -> std::io::Result<()> {
+    if a.contains_key(rel) {
+        copy_atomic(pa, pb)?;
+        record_common(common, a, rel);
+    } else if b.contains_key(rel) {
+        copy_atomic(pb, pa)?;
+        record_common(common, b, rel);
+    }
+    Ok(())
+}
+
+/// Deterministic, clock-independent winner: max blake3, so both ends pick the
+/// same side without talking. Returns `(win_root, win_fp, lose_root, lose_fp)`.
+///
+/// Ties (`fa == fb`) go to A, matching the `>=` this was lifted from.
+fn winner_loser<'r, 'f>(
+    root_a: &'r Path,
+    fa: &'f Fingerprint,
+    root_b: &'r Path,
+    fb: &'f Fingerprint,
+) -> (&'r Path, &'f Fingerprint, &'r Path, &'f Fingerprint) {
+    if fa.blake3 >= fb.blake3 {
+        (root_a, fa, root_b, fb)
+    } else {
+        (root_b, fb, root_a, fa)
+    }
+}
+
+/// Convergent conflict-copy: winner takes `rel`; the loser is preserved as
+/// `.conflict-<host>-<short_blake3>` on BOTH sides so the replicas end up with
+/// an identical file set and no version is lost.
+#[allow(clippy::too_many_arguments)]
+fn apply_both_changed(
+    root_a: &Path,
+    root_b: &Path,
+    rel: &Path,
+    a: &FpMap,
+    b: &FpMap,
+    host: &str,
+    common: &mut FpMap,
+    conflicts: &mut Vec<PathBuf>,
+) -> std::io::Result<()> {
+    let (Some(fa), Some(fb)) = (a.get(rel), b.get(rel)) else {
+        return Ok(());
+    };
+    let (win_root, win_fp, lose_root, lose_fp) = winner_loser(root_a, fa, root_b, fb);
+    let loser_name = {
+        let mut n = rel.as_os_str().to_owned();
+        n.push(format!(".conflict-{host}-{}", short_hex(&lose_fp.blake3)));
+        PathBuf::from(n)
+    };
+    let win_full = win_root.join(rel); // winner content
+    let lose_full = lose_root.join(rel); // loser content (about to be overwritten)
+                                         // 1. Preserve the loser as a conflict-copy on BOTH sides FIRST.
+    copy_atomic(&lose_full, &lose_root.join(&loser_name))?;
+    copy_atomic(&lose_full, &win_root.join(&loser_name))?;
+    // 2. Put the winner's content on both real paths (winner side already has it).
+    copy_atomic(&win_full, &lose_full)?;
+    // Both replicas now hold {rel = winner, loser_name = loser} — identical.
+    common.insert(rel.to_path_buf(), *win_fp);
+    common.insert(loser_name, *lose_fp);
+    conflicts.push(rel.to_path_buf());
+    Ok(())
+}
+
+/// Apply one reconciler decision. Every arm is dispatched in the same order and
+/// with the same short-circuiting as before; the per-arm bodies live in the
+/// helpers above so the safety-critical ordering inside each is stated once.
 #[allow(clippy::too_many_arguments)]
 fn apply(
     root_a: &Path,
@@ -156,21 +247,15 @@ fn apply(
         Action::ConvergeIdentical => {
             // Both sides already hold identical new content — no file op, just
             // record it as the new common base.
-            if let Some(fp) = a.get(rel) {
-                common.insert(rel.to_path_buf(), *fp);
-            }
+            record_common(common, a, rel);
         }
         Action::PropagateAtoB => {
             copy_atomic(&pa, &pb)?;
-            if let Some(fp) = a.get(rel) {
-                common.insert(rel.to_path_buf(), *fp);
-            }
+            record_common(common, a, rel);
         }
         Action::PropagateBtoA => {
             copy_atomic(&pb, &pa)?;
-            if let Some(fp) = b.get(rel) {
-                common.insert(rel.to_path_buf(), *fp);
-            }
+            record_common(common, b, rel);
         }
         Action::DeleteA => {
             let _ = std::fs::remove_file(&pa);
@@ -181,47 +266,10 @@ fn apply(
             common.remove(rel);
         }
         Action::Conflict(ConflictKind::DeleteVsModify) => {
-            // Keep the modification: restore the surviving side onto the deleted one.
-            if a.contains_key(rel) {
-                copy_atomic(&pa, &pb)?;
-                if let Some(fp) = a.get(rel) {
-                    common.insert(rel.to_path_buf(), *fp);
-                }
-            } else if b.contains_key(rel) {
-                copy_atomic(&pb, &pa)?;
-                if let Some(fp) = b.get(rel) {
-                    common.insert(rel.to_path_buf(), *fp);
-                }
-            }
+            apply_delete_vs_modify(&pa, &pb, rel, a, b, common)?;
         }
         Action::Conflict(ConflictKind::BothChanged) => {
-            // Convergent conflict-copy: deterministic winner = max blake3 (both
-            // ends compute the same). Winner takes `rel`; loser -> .conflict on
-            // BOTH sides so the replicas become identical.
-            let (Some(fa), Some(fb)) = (a.get(rel), b.get(rel)) else {
-                return Ok(());
-            };
-            let (win_root, win_fp, lose_root, lose_fp) = if fa.blake3 >= fb.blake3 {
-                (root_a, fa, root_b, fb)
-            } else {
-                (root_b, fb, root_a, fa)
-            };
-            let loser_name = {
-                let mut n = rel.as_os_str().to_owned();
-                n.push(format!(".conflict-{host}-{}", short_hex(&lose_fp.blake3)));
-                PathBuf::from(n)
-            };
-            let win_full = win_root.join(rel); // winner content
-            let lose_full = lose_root.join(rel); // loser content (about to be overwritten)
-                                                 // 1. Preserve the loser as a conflict-copy on BOTH sides FIRST.
-            copy_atomic(&lose_full, &lose_root.join(&loser_name))?;
-            copy_atomic(&lose_full, &win_root.join(&loser_name))?;
-            // 2. Put the winner's content on both real paths (winner side already has it).
-            copy_atomic(&win_full, &lose_full)?;
-            // Both replicas now hold {rel = winner, loser_name = loser} — identical.
-            common.insert(rel.to_path_buf(), *win_fp);
-            common.insert(loser_name, *lose_fp);
-            conflicts.push(rel.to_path_buf());
+            apply_both_changed(root_a, root_b, rel, a, b, host, common, conflicts)?;
         }
     }
     Ok(())
@@ -230,11 +278,62 @@ fn apply(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use super::super::reconcile::FileType;
     use super::*;
 
     #[test]
     fn short_hex_is_12_hex_chars() {
         assert_eq!(short_hex(&[0xab; 32]), "abababababab");
+    }
+
+    fn fp(first: u8) -> Fingerprint {
+        let mut h = [0u8; 32];
+        h[0] = first;
+        Fingerprint {
+            blake3: h,
+            ftype: FileType::File,
+        }
+    }
+
+    /// The conflict winner is max-blake3 and a TIE goes to A — this is what makes
+    /// both replicas pick the same side without talking. Extracting the `>=` into
+    /// `winner_loser` must not have flipped either case.
+    #[test]
+    fn winner_is_max_blake3_and_ties_go_to_a() {
+        let (ra, rb) = (Path::new("/a"), Path::new("/b"));
+        let (lo, hi) = (fp(1), fp(2));
+
+        let (wr, wf, lr, lf) = winner_loser(ra, &hi, rb, &lo);
+        assert_eq!((wr, lr), (ra, rb), "A holds the larger hash, so A wins");
+        assert_eq!((*wf, *lf), (hi, lo));
+
+        let (wr, wf, lr, lf) = winner_loser(ra, &lo, rb, &hi);
+        assert_eq!((wr, lr), (rb, ra), "B holds the larger hash, so B wins");
+        assert_eq!((*wf, *lf), (hi, lo));
+
+        let (wr, _, lr, _) = winner_loser(ra, &hi, rb, &hi);
+        assert_eq!((wr, lr), (ra, rb), "equal hashes must tie-break to A (>=)");
+    }
+
+    /// `record_common` replaced an inlined `if let`: when the side does not hold
+    /// the path it must do NOTHING — in particular it must not remove or clobber
+    /// an entry already in the base.
+    #[test]
+    fn record_common_is_a_noop_when_the_side_lacks_the_path() {
+        let rel = Path::new("f");
+        let mut side = FpMap::new();
+        side.insert(rel.to_path_buf(), fp(7));
+
+        let mut common = FpMap::new();
+        record_common(&mut common, &side, rel);
+        assert_eq!(common.get(rel), Some(&fp(7)), "present -> inserted");
+
+        // Absent from `side`, but already present in `common`: left untouched.
+        let mut common = FpMap::new();
+        common.insert(rel.to_path_buf(), fp(9));
+        record_common(&mut common, &FpMap::new(), rel);
+        assert_eq!(common.get(rel), Some(&fp(9)), "absent -> base unchanged");
+        assert_eq!(common.len(), 1);
     }
 
     #[test]

--- a/src/bin/copia/incremental.rs
+++ b/src/bin/copia/incremental.rs
@@ -114,16 +114,15 @@ fn report(
     Ok(())
 }
 
-#[allow(clippy::cast_possible_truncation)]
-async fn run_remote(
+/// The `(source, destination)` labels for this direction, as an operator sees
+/// them in the scan line and in the final report.
+fn endpoint_descriptions(
     dir: Dir,
     host: &str,
     remote_root: &str,
     local_root: &Path,
-    opts: &SyncOptions,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let start = Instant::now();
-    let (src_desc, dst_desc) = match dir {
+) -> (String, String) {
+    match dir {
         Dir::Push => (
             local_root.display().to_string(),
             format!("{host}:{remote_root}"),
@@ -132,27 +131,112 @@ async fn run_remote(
             format!("{host}:{remote_root}"),
             local_root.display().to_string(),
         ),
-    };
-    eprintln!("Scanning {src_desc} and {dst_desc}...");
+    }
+}
 
-    // Source drives transfers; destination drives skip + delete. A missing dest
-    // (first sync) yields an empty map, so every source file is new.
-    // Resolve each `?` into a binding BEFORE any await so no error-carrying
-    // temporary is held across it (keeps the future `Send`).
-    let (src_meta, dst_meta): (MetaMap, MetaMap) = match dir {
+/// Both sides' metadata, as `(source, destination)`.
+///
+/// Source drives transfers; destination drives skip + delete. A missing dest
+/// (first sync) yields an empty map, so every source file is new.
+/// Resolve each `?` into a binding BEFORE any await so no error-carrying
+/// temporary is held across it (keeps the future `Send`).
+async fn discover_both(
+    dir: Dir,
+    host: &str,
+    remote_root: &str,
+    local_root: &Path,
+) -> Result<(MetaMap, MetaMap), Box<dyn std::error::Error>> {
+    match dir {
         Dir::Push => {
             let local = discover_local_with_meta(local_root)?;
             let remote = discover_remote_with_meta(host, remote_root)
                 .await
                 .unwrap_or_default();
-            (local, remote)
+            Ok((local, remote))
         }
         Dir::Pull => {
             let remote = discover_remote_with_meta(host, remote_root).await?;
             let local = discover_local_with_meta(local_root).unwrap_or_default();
-            (remote, local)
+            Ok((remote, local))
         }
-    };
+    }
+}
+
+/// Create the destination-side directories this transfer needs.
+async fn create_transfer_dirs(
+    dir: Dir,
+    host: &str,
+    remote_root: &str,
+    local_root: &Path,
+    dirs: &[PathBuf],
+) -> Result<(), Box<dyn std::error::Error>> {
+    match dir {
+        Dir::Push => create_remote_dirs(host, remote_root, dirs).await,
+        Dir::Pull => create_local_dirs(local_root, dirs),
+    }
+}
+
+/// Deliver one file in this direction: push streams it up over SSH, pull
+/// streams it down into a temp sibling and renames it into place.
+async fn deliver_one(
+    dir: Dir,
+    host: &str,
+    remote_file: &str,
+    local_file: &Path,
+    mtime: Option<i64>,
+) -> Result<u64, String> {
+    match dir {
+        Dir::Push => transfer_file_to_remote(local_file, host, remote_file, mtime).await,
+        Dir::Pull => deliver_pull(host, remote_file, local_file, mtime).await,
+    }
+}
+
+/// Spawn one task per planned file, `jobs`-limited by a shared semaphore.
+/// Returns the handles in plan order plus the counters every task writes into.
+#[allow(clippy::cast_possible_truncation)]
+fn spawn_transfers(
+    dir: Dir,
+    host: &str,
+    remote_root: &str,
+    local_root: &Path,
+    transfer: &[PathBuf],
+    src_meta: &MetaMap,
+    jobs: usize,
+) -> (Vec<tokio::task::JoinHandle<()>>, TransferProgress) {
+    let semaphore = Arc::new(Semaphore::new(jobs));
+    let progress = TransferProgress::new(transfer.len() as u64);
+    let mut handles = Vec::with_capacity(transfer.len());
+    for rel in transfer {
+        let mtime = src_meta.get(rel).map(|m| m.mtime);
+        let remote_file = format!("{}/{}", remote_root, rel.display());
+        let local_file = local_root.join(rel);
+        let host = host.to_string();
+        let sem = Arc::clone(&semaphore);
+        let prog = progress.clone();
+        let rel_disp = rel.display().to_string();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await;
+            match deliver_one(dir, &host, &remote_file, &local_file, mtime).await {
+                Ok(size) => prog.record_ok(size),
+                Err(e) => prog.record_err(&rel_disp, &e),
+            }
+        }));
+    }
+    (handles, progress)
+}
+
+async fn run_remote(
+    dir: Dir,
+    host: &str,
+    remote_root: &str,
+    local_root: &Path,
+    opts: &SyncOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = Instant::now();
+    let (src_desc, dst_desc) = endpoint_descriptions(dir, host, remote_root, local_root);
+    eprintln!("Scanning {src_desc} and {dst_desc}...");
+
+    let (src_meta, dst_meta) = discover_both(dir, host, remote_root, local_root).await?;
     // Empty source short-circuits (unless mirroring, where empty source is a
     // legitimate "delete everything on the destination").
     if src_meta.is_empty() && !opts.delete {
@@ -170,34 +254,17 @@ async fn run_remote(
     }
 
     let dirs = collect_dirs(&plan.transfer);
-    match dir {
-        Dir::Push => create_remote_dirs(host, remote_root, &dirs).await?,
-        Dir::Pull => create_local_dirs(local_root, &dirs)?,
-    }
+    create_transfer_dirs(dir, host, remote_root, local_root, &dirs).await?;
 
-    let semaphore = Arc::new(Semaphore::new(opts.jobs));
-    let progress = TransferProgress::new(plan.transfer.len() as u64);
-    let mut handles = Vec::with_capacity(plan.transfer.len());
-    for rel in &plan.transfer {
-        let mtime = src_meta.get(rel).map(|m| m.mtime);
-        let remote_file = format!("{}/{}", remote_root, rel.display());
-        let local_file = local_root.join(rel);
-        let host = host.to_string();
-        let sem = Arc::clone(&semaphore);
-        let prog = progress.clone();
-        let rel_disp = rel.display().to_string();
-        handles.push(tokio::spawn(async move {
-            let _permit = sem.acquire().await;
-            let res = match dir {
-                Dir::Push => transfer_file_to_remote(&local_file, &host, &remote_file, mtime).await,
-                Dir::Pull => deliver_pull(&host, &remote_file, &local_file, mtime).await,
-            };
-            match res {
-                Ok(size) => prog.record_ok(size),
-                Err(e) => prog.record_err(&rel_disp, &e),
-            }
-        }));
-    }
+    let (handles, progress) = spawn_transfers(
+        dir,
+        host,
+        remote_root,
+        local_root,
+        &plan.transfer,
+        &src_meta,
+        opts.jobs,
+    );
     join_handles(handles).await;
 
     if !plan.delete.is_empty() {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -281,31 +281,70 @@ impl SignatureTable {
 
         // Fast path: if there's only one candidate and it's the expected one,
         // verify with strong hash (can't skip entirely for correctness)
-        if candidates.len() == 1 {
-            let sig = &self.signature.blocks[candidates[0]];
-            if sig.index == expected_index {
-                // Still verify, but this is the common case
-                let strong = StrongHash::compute(data);
-                if sig.strong_hash == strong {
-                    return Some(sig);
-                }
-            }
+        if let Some(sig) = self.match_sole_expected(candidates, data, expected_index) {
+            return Some(sig);
         }
 
         // Check expected index first if present
-        for &i in candidates {
-            let sig = &self.signature.blocks[i];
-            if sig.index == expected_index {
-                let strong = StrongHash::compute(data);
-                if sig.strong_hash == strong {
-                    return Some(sig);
-                }
-                // Expected didn't match, check others
-                break;
-            }
+        if let Some(sig) = self.match_expected_first(candidates, data, expected_index) {
+            return Some(sig);
         }
 
         // Fall back to checking all candidates
+        self.match_any(candidates, data)
+    }
+
+    /// Fast path for the single-candidate case.
+    ///
+    /// Matches only when the lone candidate carries `expected_index` and its
+    /// strong hash verifies against `data`. Any other shape — more than one
+    /// candidate, a different index, a failed verification — yields `None` and
+    /// leaves the decision to the scans that follow. The strong hash is
+    /// computed only once the index has already matched.
+    #[inline]
+    fn match_sole_expected(
+        &self,
+        candidates: &[usize],
+        data: &[u8],
+        expected_index: u32,
+    ) -> Option<&BlockSignature> {
+        if candidates.len() != 1 {
+            return None;
+        }
+        let sig = &self.signature.blocks[candidates[0]];
+        if sig.index != expected_index {
+            return None;
+        }
+        // Still verify, but this is the common case
+        let strong = StrongHash::compute(data);
+        (sig.strong_hash == strong).then_some(sig)
+    }
+
+    /// Verify the expected block ahead of any other candidate.
+    ///
+    /// Stops at the first candidate carrying `expected_index` and verifies only
+    /// that one; if it fails to verify this gives up rather than resuming the
+    /// scan, so the caller falls back to the full scan. When no candidate
+    /// carries `expected_index` no strong hash is computed at all.
+    #[inline]
+    fn match_expected_first(
+        &self,
+        candidates: &[usize],
+        data: &[u8],
+        expected_index: u32,
+    ) -> Option<&BlockSignature> {
+        let sig = candidates
+            .iter()
+            .map(|&i| &self.signature.blocks[i])
+            .find(|sig| sig.index == expected_index)?;
+        let strong = StrongHash::compute(data);
+        (sig.strong_hash == strong).then_some(sig)
+    }
+
+    /// Full scan: the first candidate, in candidate order, whose strong hash
+    /// matches `data`.
+    #[inline]
+    fn match_any(&self, candidates: &[usize], data: &[u8]) -> Option<&BlockSignature> {
         let strong = StrongHash::compute(data);
         candidates
             .iter()
@@ -695,6 +734,180 @@ mod tests {
         assert!(SignatureTable::validate_block_size(1000).is_err());
         assert!(SignatureTable::validate_block_size(1023).is_err());
         assert!(SignatureTable::validate_block_size(1025).is_err());
+    }
+
+    // ==========================================================================
+    // FIND_MATCH_OPTIMIZED CHARACTERIZATION TESTS
+    // ==========================================================================
+    //
+    // These pin every path through `find_match_optimized`: the sole-candidate
+    // fast path, the expected-index-first scan, the break out of that scan into
+    // the full scan, and which block wins when more than one could.
+
+    /// Build a table from hand-written blocks so weak-hash collisions and
+    /// index/expectation mismatches can be constructed deliberately.
+    fn table_of(blocks: Vec<BlockSignature>) -> SignatureTable {
+        SignatureTable::from_signature(Signature {
+            block_size: 512,
+            file_size: 0,
+            blocks,
+        })
+    }
+
+    #[test]
+    fn find_match_optimized_no_weak_candidate() {
+        let table = table_of(vec![BlockSignature::new(0, 111, StrongHash::compute(b"a"))]);
+        assert!(table.find_match_optimized(222, b"a", 0).is_none());
+    }
+
+    #[test]
+    fn find_match_optimized_sole_candidate_is_expected() {
+        let table = table_of(vec![BlockSignature::new(
+            7,
+            111,
+            StrongHash::compute(b"payload"),
+        )]);
+        let found = table.find_match_optimized(111, b"payload", 7).unwrap();
+        assert_eq!(found.index, 7);
+    }
+
+    #[test]
+    fn find_match_optimized_sole_candidate_weak_collision_rejected() {
+        // Same weak hash, different content: the strong hash must reject it.
+        let table = table_of(vec![BlockSignature::new(
+            7,
+            111,
+            StrongHash::compute(b"other"),
+        )]);
+        assert!(table.find_match_optimized(111, b"payload", 7).is_none());
+    }
+
+    #[test]
+    fn find_match_optimized_sole_candidate_wrong_index_still_matches() {
+        // Not the expected index, so the fast path and the expected-first scan
+        // both decline; the full scan still returns it.
+        let table = table_of(vec![BlockSignature::new(
+            7,
+            111,
+            StrongHash::compute(b"payload"),
+        )]);
+        let found = table.find_match_optimized(111, b"payload", 3).unwrap();
+        assert_eq!(found.index, 7);
+    }
+
+    #[test]
+    fn find_match_optimized_expected_found_late_in_candidates() {
+        let table = table_of(vec![
+            BlockSignature::new(3, 111, StrongHash::compute(b"other")),
+            BlockSignature::new(7, 111, StrongHash::compute(b"payload")),
+        ]);
+        let found = table.find_match_optimized(111, b"payload", 7).unwrap();
+        assert_eq!(found.index, 7);
+    }
+
+    #[test]
+    fn find_match_optimized_expected_beats_earlier_identical_block() {
+        // Two blocks with the SAME strong hash: the expected index wins, which
+        // is the whole point of the expected-first scan.
+        let table = table_of(vec![
+            BlockSignature::new(2, 111, StrongHash::compute(b"payload")),
+            BlockSignature::new(7, 111, StrongHash::compute(b"payload")),
+        ]);
+        let found = table.find_match_optimized(111, b"payload", 7).unwrap();
+        assert_eq!(found.index, 7);
+    }
+
+    #[test]
+    fn find_match_optimized_expected_mismatch_falls_back_to_others() {
+        // The expected block is present but its content differs: the scan stops
+        // at it (break) and the full scan finds the real match.
+        let table = table_of(vec![
+            BlockSignature::new(7, 111, StrongHash::compute(b"wrong")),
+            BlockSignature::new(9, 111, StrongHash::compute(b"payload")),
+        ]);
+        let found = table.find_match_optimized(111, b"payload", 7).unwrap();
+        assert_eq!(found.index, 9);
+    }
+
+    /// TWO candidates carry `expected_index`, and the first does not match.
+    ///
+    /// `find_match_optimized_expected_mismatch_falls_back_to_others` is the test
+    /// that was believed to pin the break-vs-continue semantics of the
+    /// expected-first scan. It does not: it builds only ONE candidate carrying
+    /// `expected_index`, and with one candidate `break` and `continue` are
+    /// indistinguishable. An adversarial review injected exactly that change —
+    /// resuming the scan instead of breaking — and all eleven characterization
+    /// tests still passed.
+    ///
+    /// This is the discriminating input. With a second `index == 7` that DOES
+    /// match, `break` yields index 3 (the full scan's first hit) while a
+    /// resuming scan yields index 7.
+    ///
+    /// Reachable, not theoretical: `Signature::generate` assigns `index` from
+    /// `enumerate()` so duplicates cannot arise from generation, but `Signature`
+    /// derives `Deserialize` — a corrupt or hostile signature file can carry
+    /// them.
+    #[test]
+    fn find_match_optimized_two_candidates_share_the_expected_index() {
+        let table = table_of(vec![
+            BlockSignature::new(7, 111, StrongHash::compute(b"wrong")),
+            BlockSignature::new(3, 111, StrongHash::compute(b"payload")),
+            BlockSignature::new(7, 111, StrongHash::compute(b"payload")),
+        ]);
+        let found = table.find_match_optimized(111, b"payload", 7).unwrap();
+        assert_eq!(
+            found.index, 3,
+            "the expected-first scan must BREAK on the first expected-index \
+             candidate, not resume past it"
+        );
+    }
+
+    #[test]
+    fn find_match_optimized_expected_absent_falls_back() {
+        let table = table_of(vec![
+            BlockSignature::new(3, 111, StrongHash::compute(b"payload")),
+            BlockSignature::new(9, 111, StrongHash::compute(b"x")),
+        ]);
+        let found = table.find_match_optimized(111, b"payload", 7).unwrap();
+        assert_eq!(found.index, 3);
+    }
+
+    #[test]
+    fn find_match_optimized_no_strong_match_returns_none() {
+        let table = table_of(vec![
+            BlockSignature::new(3, 111, StrongHash::compute(b"a")),
+            BlockSignature::new(9, 111, StrongHash::compute(b"b")),
+        ]);
+        assert!(table.find_match_optimized(111, b"payload", 7).is_none());
+    }
+
+    #[test]
+    fn find_match_optimized_full_scan_returns_first_duplicate() {
+        // Neither is the expected index and both match: candidate order wins.
+        let table = table_of(vec![
+            BlockSignature::new(5, 111, StrongHash::compute(b"payload")),
+            BlockSignature::new(6, 111, StrongHash::compute(b"payload")),
+        ]);
+        let found = table.find_match_optimized(111, b"payload", 99).unwrap();
+        assert_eq!(found.index, 5);
+    }
+
+    #[test]
+    fn find_match_optimized_agrees_with_find_match_when_index_unknown() {
+        // With no expected index in play, the optimized lookup must return the
+        // same block as the plain one.
+        let data = vec![7u8; 4096];
+        let mut cursor = Cursor::new(data.as_slice());
+        let table = SignatureTable::build(&mut cursor, 1024).unwrap();
+        let block = &data[..1024];
+        let weak = RollingChecksum::new(block).digest();
+
+        let plain = table.find_match(weak, block).unwrap().index;
+        let optimized = table
+            .find_match_optimized(weak, block, u32::MAX)
+            .unwrap()
+            .index;
+        assert_eq!(plain, optimized);
     }
 
     // ==========================================================================

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -268,44 +268,7 @@ impl Sync for CopiaSync {
             return Ok(delta);
         }
 
-        let mut pos = 0usize;
-
-        // Initialize rolling checksum with first block
-        let init_len = block_size.min(source_data.len());
-        let mut rolling = FastRollingChecksum::new(&source_data[..init_len]);
-
-        while pos + block_size <= source_data.len() {
-            let weak = rolling.digest();
-
-            // Fast path: check weak hash first before computing strong hash
-            if table.has_weak_match(weak) {
-                let block_data = &source_data[pos..pos + block_size];
-                if let Some(sig) = table.find_match(weak, block_data) {
-                    // Found a match - emit copy operation
-                    #[allow(clippy::cast_possible_truncation)]
-                    {
-                        let offset = u64::from(sig.index) * block_size as u64;
-                        delta.push_copy(offset, block_size as u32);
-                    }
-                    pos += block_size;
-
-                    // After match, we need new checksum at new position
-                    // Roll forward by block_size bytes OR reinit (same cost)
-                    if pos + block_size <= source_data.len() {
-                        rolling = FastRollingChecksum::new(&source_data[pos..pos + block_size]);
-                    }
-                    continue;
-                }
-            }
-
-            // No match - emit literal byte and roll window
-            delta.push_literal_byte(source_data[pos]);
-
-            if pos + block_size < source_data.len() {
-                rolling.roll(source_data[pos], source_data[pos + block_size]);
-            }
-            pos += 1;
-        }
+        let pos = scan_blocks(&table, &source_data, block_size, &mut delta);
 
         // Handle remaining bytes as literals
         if pos < source_data.len() {
@@ -393,6 +356,75 @@ impl Sync for CopiaSync {
 
         Ok(())
     }
+}
+
+/// Look up the block at `pos` in the signature table.
+///
+/// Checks the weak (rolling) hash first and only computes the strong hash when
+/// the weak hash has candidates. Returns the basis-file offset of the matching
+/// block, or `None` when the block does not match.
+#[allow(clippy::cast_possible_truncation)] // block_size validated to be <= 65536
+fn match_block_at(
+    table: &SignatureTable,
+    source_data: &[u8],
+    pos: usize,
+    block_size: usize,
+    weak: u32,
+) -> Option<u64> {
+    // Fast path: check weak hash first before computing strong hash
+    if !table.has_weak_match(weak) {
+        return None;
+    }
+
+    let block_data = &source_data[pos..pos + block_size];
+    let sig = table.find_match(weak, block_data)?;
+    Some(u64::from(sig.index) * block_size as u64)
+}
+
+/// Scan `source_data` for blocks present in `table`, pushing copy and literal
+/// ops onto `delta`.
+///
+/// Returns the position of the first byte not yet emitted; the caller flushes
+/// the trailing remainder (shorter than one block) as a literal.
+#[allow(clippy::cast_possible_truncation)] // block_size validated to be <= 65536
+fn scan_blocks(
+    table: &SignatureTable,
+    source_data: &[u8],
+    block_size: usize,
+    delta: &mut Delta,
+) -> usize {
+    let mut pos = 0usize;
+
+    // Initialize rolling checksum with first block
+    let init_len = block_size.min(source_data.len());
+    let mut rolling = FastRollingChecksum::new(&source_data[..init_len]);
+
+    while pos + block_size <= source_data.len() {
+        let weak = rolling.digest();
+
+        if let Some(offset) = match_block_at(table, source_data, pos, block_size, weak) {
+            // Found a match - emit copy operation
+            delta.push_copy(offset, block_size as u32);
+            pos += block_size;
+
+            // After match, we need new checksum at new position
+            // Roll forward by block_size bytes OR reinit (same cost)
+            if pos + block_size <= source_data.len() {
+                rolling = FastRollingChecksum::new(&source_data[pos..pos + block_size]);
+            }
+            continue;
+        }
+
+        // No match - emit literal byte and roll window
+        delta.push_literal_byte(source_data[pos]);
+
+        if pos + block_size < source_data.len() {
+            rolling.roll(source_data[pos], source_data[pos + block_size]);
+        }
+        pos += 1;
+    }
+
+    pos
 }
 
 /// Statistics from a sync operation.


### PR DESCRIPTION
Complexity violations: **0**.

`pmat.toml` sets cognitive complexity **20**. The release gate uses 25 and caught only the worst function (`is_excluded` at 33, #52). Treating the other five as acceptable because CI is looser would be choosing whichever of two numbers copia publishes about itself is convenient — which is how a limit becomes decorative.

| function | before | after |
|---|---|---|
| `src/async_sync.rs` delta | 23 | **7** |
| `src/sync.rs` delta | 23 | **7** |
| `src/signature.rs` find_match_optimized | 23 | **6** |
| `src/bin/copia/bidir.rs` apply | 21 | **1** |
| `src/bin/copia/incremental.rs` run_remote | 20 | **12** |

These are core sync paths — delta computation, rolling-hash matching, bidirectional apply — where a subtle change **corrupts data rather than failing loudly**. Every refactor kept its branches and stopped stacking them. Nothing was deleted or merged under the banner of simplification.

## One reviewer verified by execution, not by reading

A differential harness driving the public API against a pristine HEAD worktree: **10,808 cases, 5,456,306 bytes of serialized op stream, byte-identical** on both sides. The harness was itself falsified — 4 of 5 injected mutations detected, including flipping a re-seed guard from `<=` to `<`.

## A test that was not testing anything

`find_match_optimized_expected_mismatch_falls_back_to_others` was believed to pin the break-vs-continue semantics of the expected-first scan. It builds **one** candidate carrying `expected_index` — and with one candidate, `break` and `continue` are indistinguishable. A reviewer injected exactly that change and **all eleven characterization tests still passed**.

`find_match_optimized_two_candidates_share_the_expected_index` is the discriminating input. Falsified: with the injection it fails `left: 7, right: 3`, **and the old test still passes** — which is the proof it was vacuous.

Reachable, not theoretical: `Signature::generate` assigns indices from `enumerate()`, but `Signature` derives `Deserialize` — a corrupt or hostile signature file can carry duplicates.

## README

The doc-sections check wanted Installation / Usage / Contributing. Two were renames of sections that already existed; **Contributing was genuinely absent**, and a placeholder to satisfy a string match would have been appeasement. It now states the two things that actually fail a contributor’s build.

Also clean: dead code, SATD, entropy, security, duplicates, doc sections. Coverage reports **UNMEASURED** and says so rather than passing silently.

**395 tests pass**, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf