### PR TITLE
chore(ci): bump the five pinned actions, and pin the one that was not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
     name: benchmarks
     runs-on: [self-hosted, clean-room]
     steps:
-      - uses: actions/checkout@v5
+      # Pinned to a SHA like every other workflow in this repo. `@v5` is a
+      # MUTABLE tag: whoever controls the tag controls what runs here, and a
+      # repointed tag is indistinguishable from no change at all in a diff.
+      # Same SHA as the rest of the repo, so there is one version of checkout
+      # everywhere rather than two that drift apart.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Compile + smoke-run benchmarks
         run: cargo bench --features async -- --test
       - name: Validate provable contracts (schema)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,8 +81,14 @@ jobs:
         run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\provable-contracts" -Target "$env:GITHUB_WORKSPACE\provable-contracts" -Force
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # SHA-pinned, like every other action here. `@stable` is a BRANCH on
+        # that repo — it selects the toolchain AND floats the action's own code,
+        # so a change to either arrives with no diff on our side. Pinning the
+        # code and naming the toolchain explicitly separates the two: the action
+        # is frozen, Rust stable still tracks stable.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable @ 2026-08-23
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Ensure target is installed

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       has_commits: ${{ steps.check.outputs.has_commits }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -63,10 +63,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Checkout provable-contracts (path dep)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: paiml/provable-contracts
           path: provable-contracts
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload artifact (unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: copia-${{ matrix.target }}
           path: |
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload artifact (windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: copia-${{ matrix.target }}
           path: |
@@ -143,10 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
@@ -158,7 +158,7 @@ jobs:
           gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
 
       - name: Create nightly release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           tag_name: nightly
           name: Nightly Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       has_binaries: ${{ steps.bincheck.outputs.has_binaries }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Parse tag and verify version
         id: parse
@@ -117,7 +117,7 @@ jobs:
     runs-on: [self-hosted, clean-room]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Verify package tarball
         run: |
@@ -134,10 +134,10 @@ jobs:
     runs-on: [self-hosted, clean-room]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Authenticate to crates.io (OIDC)
-        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec  # v1.0.3
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
 
       - name: Publish
         run: |
@@ -169,7 +169,7 @@ jobs:
       CROSS_VERSION: v0.2.5
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install target prerequisites
         run: |


### PR DESCRIPTION
Consolidates five dependabot PRs (#10, #11, #15, #16, #25) that have sat since **March**. Merging them individually means five full CI runs against a repo whose workflows have changed substantially since — each landing on a base it was never tested against.

SHAs are dependabot’s own, taken from the PR diffs rather than looked up:

| action | from | to |
|---|---|---|
| `actions/checkout` | v4.2.2 | v6.0.2 |
| `actions/upload-artifact` | v4.6.2 | v7.0.0 |
| `actions/download-artifact` | v4.3.0 | v8.0.1 |
| `softprops/action-gh-release` | v2.2.2 | v2.6.1 |
| `rust-lang/crates-io-auth-action` | v1.0.3 | v1.0.4 |

## Not busywork — the need is observable

A copia run **today** emitted:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/upload-artifact@65c4c4a1...
```

## Also fixed, found while checking the pins

`ci.yml` used **`actions/checkout@v5` — a mutable tag**, while every other workflow pins a SHA. Whoever controls that tag controls what runs in CI, and **a repointed tag is indistinguishable from no change at all in a diff**.

Pinned to the same SHA as the rest of the repo, so there is one version of checkout everywhere rather than two that drift apart. **Correction, and it is the useful part of this PR.** My first audit printed one I had already claimed was gone: `dtolnay/rust-toolchain@stable`. `@stable` is a *branch* doing two jobs — selecting the toolchain AND floating the action code — so it reads like a version while behaving like `@main`. Now pinned to a SHA with `toolchain: stable` named explicitly, which separates the two. Re-audited after: **zero mutable action references remain**, and this time the statement follows the check rather than preceding it.

Closes #10, closes #11, closes #15, closes #16, closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf