### PR TITLE
fix(release): hand the OIDC token to cargo — publish fetched one and dropped it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,10 +146,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # `id:` is load-bearing. The action does not export a token into the
+      # environment — it emits one as a STEP OUTPUT, and an output nothing reads
+      # is discarded. Without the id there is nothing to reference it by.
       - name: Authenticate to crates.io (OIDC)
+        id: auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
 
       - name: Publish
+        # The failure this fixes reads as an auth failure and is not one:
+        #
+        #   Retrieved token successfully
+        #   error: no token found, please run `cargo login`
+        #
+        # OIDC worked. crates.io issued a token. Nothing handed it to cargo, and
+        # the run then dutifully revoked the token it had never used.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           CRATE="${{ needs.create-release.outputs.crate_name }}"
           if [ -n "$CRATE" ]; then


### PR DESCRIPTION
v0.3.0 passed every gate, passed `verify`, and failed at `publish`:

```
Retrieved token successfully
error: no token found, please run `cargo login`
Token revoked successfully
```

**That reads as an auth failure and is not one.** OIDC worked, crates.io issued a token, nothing handed it to cargo, and the run then dutifully revoked the token it had never used.

`rust-lang/crates-io-auth-action` does not export anything into the environment — it emits the token as a **step output**. Two things were required and neither was present: an `id:` on the auth step to reference it by, and `CARGO_REGISTRY_TOKEN` on the publish step to consume it.

## Not a regression from my version bump

That was my first suspicion, since I moved this action v1.0.3 → v1.0.4 an hour ago. The history shows the publish step has **never** had an `id:` or that env var — only the SHA ever changed.

## The publish job has never run to completion

Last six `release.yml` runs:

| date | publish job |
|---|---|
| 2026-08-23 | failure |
| 2026-08-23 | skipped |
| 2026-08-23 | skipped |
| 2026-07-04 | **no publish job** |
| 2026-03-06 | **no publish job** |
| 2026-03-06 | **no publish job** |

It was added when `release.yml` was rewritten and has never been exercised. v0.2.0 reached crates.io another way — this fleet has a documented habit of publishing by hand when release.yml fails, which is exactly how a never-run publish path survives unnoticed.

## Third defect in the chain

Each was revealed by fixing the one before: `pmat quality-gate` (#52, #53), `cargo package --verify` being a flag that does not exist (#56), and now a token fetched and discarded. All three sat behind a release path that had not completed since **2026-07-04**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf