### PR TITLE
fix(release): aarch64-musl stripped with the gnu tool, so v0.3.0 shipped 3 of 4 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,10 +249,27 @@ jobs:
             BIN_PATH="target/${TARGET}/release-lto/$BIN"
             case "$TARGET" in
               aarch64-*)
-                # Strip via cross Docker image with target-appropriate strip tool
+                # Each cross image ships only ITS OWN strip. Hardcoding the gnu
+                # name failed the v0.3.0 release with
+                #   exec aarch64-linux-gnu-strip failed: No such file or directory
+                # in the musl job — AFTER publish had already succeeded, so the
+                # release went out missing one of its four binaries.
+                #
+                # Verified by listing /usr/bin in both images rather than
+                # assuming the naming: the musl image has aarch64-linux-musl-strip
+                # and NO gnu one; the gnu image has aarch64-linux-gnu-strip.
+                # Both also carry a bare `strip` and an x86_64-linux-gnu-strip;
+                # those are the HOST tools, not the target's. Resolve the
+                # target-specific one and fail loudly if the triple is new,
+                # rather than reaching for whichever name happens to exist.
+                case "$TARGET" in
+                  *-musl) STRIP_TOOL="aarch64-linux-musl-strip" ;;
+                  *-gnu)  STRIP_TOOL="aarch64-linux-gnu-strip" ;;
+                  *) echo "::error::no strip tool known for $TARGET"; exit 1 ;;
+                esac
                 docker run --rm -v "$PWD/target:/target:Z" \
                   "ghcr.io/cross-rs/${TARGET}:main" \
-                  aarch64-linux-gnu-strip "/$BIN_PATH"
+                  "$STRIP_TOOL" "/$BIN_PATH"
                 ;;
               *)
                 strip "$BIN_PATH"


### PR DESCRIPTION
## What broke

`Strip binaries` hardcoded `aarch64-linux-gnu-strip` for every `aarch64-*` target. The cross images do not share tools — the musl image carries `aarch64-linux-musl-strip` and no gnu one. The musl job died with

```
exec aarch64-linux-gnu-strip failed: No such file or directory
```

and exit 127, **after `publish` had already succeeded.**

## Why it matters more than the red X suggests

0.3.0 is on crates.io and the GitHub release exists, both correct. It is simply missing the `aarch64-unknown-linux-musl` archive. A release that is 3/4 complete and reports failure at the very end is the worst shape: the artifact most people pull is fine, so nobody investigates the red run, and the gap is visible only to whoever wanted that one target.

## The fix

Resolve the strip tool from the triple, and fail with a named error on an unrecognised one rather than reaching for whichever name happens to exist.

Verified by listing `/usr/bin` in both images rather than assuming the naming convention held:

| image | strip tools present |
|---|---|
| `aarch64-unknown-linux-musl` | `strip`, `x86_64-linux-gnu-strip`, **`aarch64-linux-musl-strip`** |
| `aarch64-unknown-linux-gnu` | `strip`, `x86_64-linux-gnu-strip`, **`aarch64-linux-gnu-strip`** |

Note both images also carry a bare `strip` and an `x86_64-linux-gnu-strip`. Those are the **host** tools — a fallback to "whichever name exists" would have made this job green while stripping an aarch64 binary with an x86_64 tool.

## Verification

Re-running the release after merge should produce 4/4 binaries. That is the check that matters; the YAML parsing clean is not evidence the tool name is right.